### PR TITLE
Update for customizable RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A python library for managing authentication, backed by [PropelAuth](https://www
 
 ## Documentation
 
-- Full reference this library is [here](https://docs.propelauth.com/reference/backend-apis/python.html)
+- Full reference this library is [here](https://docs.propelauth.com/reference/backend-apis/python)
 - Getting started guides for PropelAuth are [here](https://docs.propelauth.com/)
 
 ## Questions?

--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -9,24 +9,49 @@ from propelauth_py.api import _fetch_token_verification_metadata, TokenVerificat
     _delete_user, _disable_user, _enable_user, _allow_org_to_setup_saml_connection, \
     _disallow_org_to_setup_saml_connection
 from propelauth_py.auth_fns import wrap_validate_access_token_and_get_user, \
-    wrap_validate_access_token_and_get_user_with_org, validate_org_access_and_get_org
+    wrap_validate_access_token_and_get_user_with_org_by_minimum_role, \
+    wrap_validate_access_token_and_get_user_with_org_by_exact_role, \
+    wrap_validate_access_token_and_get_user_with_org_by_permission, \
+    wrap_validate_access_token_and_get_user_with_org_by_all_permissions, \
+    validate_minimum_org_role_and_get_org, \
+    validate_exact_org_role_and_get_org, \
+    validate_permission_and_get_org, \
+    validate_all_permissions_and_get_org
 from propelauth_py.errors import UnauthorizedException
 from propelauth_py.validation import _validate_url
 
 Auth = namedtuple("Auth", [
-    "validate_access_token_and_get_user", "validate_access_token_and_get_user_with_org",
-    "validate_org_access_and_get_org",
-    "fetch_user_metadata_by_user_id", "fetch_user_metadata_by_email", "fetch_user_metadata_by_username",
+    "validate_access_token_and_get_user",
+    "validate_access_token_and_get_user_with_org_by_minimum_role",
+    "validate_access_token_and_get_user_with_org_by_exact_role",
+    "validate_access_token_and_get_user_with_org_by_permission",
+    "validate_access_token_and_get_user_with_org_by_all_permissions",
+    "validate_minimum_org_role_and_get_org",
+    "validate_exact_org_role_and_get_org",
+    "validate_permission_and_get_org",
+    "validate_all_permissions_and_get_org",    
+    "fetch_user_metadata_by_user_id",
+    "fetch_user_metadata_by_email",
+    "fetch_user_metadata_by_username",
     "fetch_batch_user_metadata_by_user_ids",
     "fetch_batch_user_metadata_by_emails",
     "fetch_batch_user_metadata_by_usernames",
-    "fetch_org", "fetch_org_by_query", "fetch_users_by_query", "fetch_users_in_org",
+    "fetch_org",
+    "fetch_org_by_query",
+    "fetch_users_by_query",
+    "fetch_users_in_org",
     "create_user",
     "update_user_email",
     "update_user_metadata",
-    "create_magic_link", "migrate_user_from_external_source", "create_org", "add_user_to_org",
-    "delete_user", "disable_user", "enable_user",
-    "allow_org_to_setup_saml_connection", "disallow_org_to_setup_saml_connection"
+    "create_magic_link",
+    "migrate_user_from_external_source",
+    "create_org",
+    "add_user_to_org",
+    "delete_user",
+    "disable_user",
+    "enable_user",
+    "allow_org_to_setup_saml_connection",
+    "disallow_org_to_setup_saml_connection"
 ])
 
 
@@ -113,13 +138,37 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
         return _disallow_org_to_setup_saml_connection(auth_url, api_key, org_id)
 
     validate_access_token_and_get_user = wrap_validate_access_token_and_get_user(token_verification_metadata)
-    validate_access_token_and_get_user_with_org = wrap_validate_access_token_and_get_user_with_org(
+
+    validate_access_token_and_get_user_with_org_by_minimum_role = wrap_validate_access_token_and_get_user_with_org_by_minimum_role(
         token_verification_metadata
     )
+
+    validate_access_token_and_get_user_with_org_by_exact_role = wrap_validate_access_token_and_get_user_with_org_by_exact_role(
+        token_verification_metadata
+    )
+
+    validate_access_token_and_get_user_with_org_by_permission= wrap_validate_access_token_and_get_user_with_org_by_permission(
+        token_verification_metadata
+    )
+
+    validate_access_token_and_get_user_with_org_by_all_permissions = wrap_validate_access_token_and_get_user_with_org_by_all_permissions(
+        token_verification_metadata
+    )
+
     return Auth(
+        # validation functions
+        validate_minimum_org_role_and_get_org=validate_minimum_org_role_and_get_org,
+        validate_exact_org_role_and_get_org=validate_exact_org_role_and_get_org,
+        validate_permission_and_get_org=validate_permission_and_get_org,
+        validate_all_permissions_and_get_org=validate_all_permissions_and_get_org,
+
+        # wrappers for the validation functions
         validate_access_token_and_get_user=validate_access_token_and_get_user,
-        validate_access_token_and_get_user_with_org=validate_access_token_and_get_user_with_org,
-        validate_org_access_and_get_org=validate_org_access_and_get_org,
+        validate_access_token_and_get_user_with_org_by_minimum_role=validate_access_token_and_get_user_with_org_by_minimum_role,
+        validate_access_token_and_get_user_with_org_by_exact_role=validate_access_token_and_get_user_with_org_by_exact_role,
+        validate_access_token_and_get_user_with_org_by_permission=validate_access_token_and_get_user_with_org_by_permission,
+        validate_access_token_and_get_user_with_org_by_all_permissions=validate_access_token_and_get_user_with_org_by_all_permissions,
+
         fetch_user_metadata_by_user_id=fetch_user_metadata_by_user_id,
         fetch_user_metadata_by_email=fetch_user_metadata_by_email,
         fetch_user_metadata_by_username=fetch_user_metadata_by_username,

--- a/propelauth_py/auth_fns.py
+++ b/propelauth_py/auth_fns.py
@@ -2,6 +2,7 @@ from propelauth_py.errors import UnauthorizedException, ForbiddenException
 from propelauth_py.jwt import _validate_access_token_and_get_user
 from propelauth_py.user import UserAndOrgMemberInfo
 
+# wrapper functions
 
 def wrap_validate_access_token_and_get_user(token_verification_metadata):
     def validate_access_token_and_get_user(authorization_header):
@@ -12,17 +13,90 @@ def wrap_validate_access_token_and_get_user(token_verification_metadata):
     return validate_access_token_and_get_user
 
 
-def wrap_validate_access_token_and_get_user_with_org(token_verification_metadata):
-    def validate_access_token_and_get_user_with_org(authorization_header, required_org_id, minimum_required_role=None):
+def wrap_validate_access_token_and_get_user_with_org_by_minimum_role(token_verification_metadata):
+    def validate_access_token_and_get_user_with_org_by_minimum_role(authorization_header, required_org_id, minimum_required_role=None):
         access_token = _extract_token_from_authorization_header(authorization_header)
         user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
-        org_member_info = validate_org_access_and_get_org(user, required_org_id, minimum_required_role)
+        org_member_info = validate_minimum_org_role_and_get_org(user, required_org_id, minimum_required_role)
         return UserAndOrgMemberInfo(user, org_member_info)
 
-    return validate_access_token_and_get_user_with_org
+    return validate_access_token_and_get_user_with_org_by_minimum_role
 
 
-def validate_org_access_and_get_org(user, required_org_id, required_role):
+def wrap_validate_access_token_and_get_user_with_org_by_exact_role(token_verification_metadata):
+    def validate_access_token_and_get_user_with_org_by_exact_role(authorization_header, required_org_id, minimum_required_role=None):
+        access_token = _extract_token_from_authorization_header(authorization_header)
+        user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
+        org_member_info = validate_exact_org_role_and_get_org(user, required_org_id, minimum_required_role)
+        return UserAndOrgMemberInfo(user, org_member_info)
+
+    return validate_access_token_and_get_user_with_org_by_exact_role
+
+
+def wrap_validate_access_token_and_get_user_with_org_by_permission(token_verification_metadata):
+    def validate_access_token_and_get_user_with_org_by_permission(authorization_header, required_org_id, minimum_required_role=None):
+        access_token = _extract_token_from_authorization_header(authorization_header)
+        user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
+        org_member_info = validate_permission_and_get_org(user, required_org_id, minimum_required_role)
+        return UserAndOrgMemberInfo(user, org_member_info)
+
+    return validate_access_token_and_get_user_with_org_by_permission
+
+
+def wrap_validate_access_token_and_get_user_with_org_by_all_permissions(token_verification_metadata):
+    def validate_access_token_and_get_user_with_org_by_all_permissions(authorization_header, required_org_id, minimum_required_role=None):
+        access_token = _extract_token_from_authorization_header(authorization_header)
+        user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
+        org_member_info = validate_all_permissions_and_get_org(user, required_org_id, minimum_required_role)
+        return UserAndOrgMemberInfo(user, org_member_info)
+
+    return validate_access_token_and_get_user_with_org_by_all_permissions
+
+# validation functions
+
+def validate_minimum_org_role_and_get_org(user, required_org_id, minimum_role):
+    """returns the org is the user is or inherits from the role specified"""
+    org_member_info = _verify_basic_access_and_get_org_member_info(user, required_org_id)
+
+    if minimum_role is not None and not org_member_info.user_is_at_least_role(minimum_role):
+        raise ForbiddenException.user_doesnt_have_required_role()
+
+    return org_member_info
+
+
+def validate_exact_org_role_and_get_org(user, required_org_id, exact_role):
+    """returns the org is the user has the exact role specified"""
+    org_member_info = _verify_basic_access_and_get_org_member_info(user, required_org_id)
+
+    if exact_role is not None and not org_member_info.user_is_role(exact_role):
+        raise ForbiddenException.user_doesnt_have_required_role()
+
+    return org_member_info
+
+
+def validate_permission_and_get_org(user, required_org_id, permission):
+    """returns the org is the user has the permission specified"""
+    org_member_info = _verify_basic_access_and_get_org_member_info(user, required_org_id)
+
+    if permission is not None and not org_member_info.user_has_permission(permission):
+        raise ForbiddenException.user_doesnt_have_required_permission()
+
+    return org_member_info
+
+
+def validate_all_permissions_and_get_org(user, required_org_id, permissions):
+    """returns the org is the user has the permission specified"""
+    org_member_info = _verify_basic_access_and_get_org_member_info(user, required_org_id)
+
+    if permissions is not None and not org_member_info.user_has_all_permissions(permissions):
+        raise ForbiddenException.user_doesnt_have_required_permission()
+
+    return org_member_info
+
+# helper functions
+
+def _verify_basic_access_and_get_org_member_info(user, required_org_id):
+    """performs basic verifications and returns the org member info"""
     if required_org_id is None:
         raise ForbiddenException.unknown_required_org()
 
@@ -33,10 +107,7 @@ def validate_org_access_and_get_org(user, required_org_id, required_role):
     org_member_info = org_id_to_org_member_info.get(required_org_id)
     if org_member_info is None:
         raise ForbiddenException.user_not_member_of_org(required_org_id)
-
-    if required_role is not None and not org_member_info.can_do_role(required_role):
-        raise ForbiddenException.user_doesnt_have_required_role()
-
+    
     return org_member_info
 
 

--- a/propelauth_py/auth_fns.py
+++ b/propelauth_py/auth_fns.py
@@ -24,30 +24,30 @@ def wrap_validate_access_token_and_get_user_with_org_by_minimum_role(token_verif
 
 
 def wrap_validate_access_token_and_get_user_with_org_by_exact_role(token_verification_metadata):
-    def validate_access_token_and_get_user_with_org_by_exact_role(authorization_header, required_org_id, minimum_required_role=None):
+    def validate_access_token_and_get_user_with_org_by_exact_role(authorization_header, required_org_id, required_role=None):
         access_token = _extract_token_from_authorization_header(authorization_header)
         user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
-        org_member_info = validate_exact_org_role_and_get_org(user, required_org_id, minimum_required_role)
+        org_member_info = validate_exact_org_role_and_get_org(user, required_org_id, required_role)
         return UserAndOrgMemberInfo(user, org_member_info)
 
     return validate_access_token_and_get_user_with_org_by_exact_role
 
 
 def wrap_validate_access_token_and_get_user_with_org_by_permission(token_verification_metadata):
-    def validate_access_token_and_get_user_with_org_by_permission(authorization_header, required_org_id, minimum_required_role=None):
+    def validate_access_token_and_get_user_with_org_by_permission(authorization_header, required_org_id, permission=None):
         access_token = _extract_token_from_authorization_header(authorization_header)
         user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
-        org_member_info = validate_permission_and_get_org(user, required_org_id, minimum_required_role)
+        org_member_info = validate_permission_and_get_org(user, required_org_id, permission)
         return UserAndOrgMemberInfo(user, org_member_info)
 
     return validate_access_token_and_get_user_with_org_by_permission
 
 
 def wrap_validate_access_token_and_get_user_with_org_by_all_permissions(token_verification_metadata):
-    def validate_access_token_and_get_user_with_org_by_all_permissions(authorization_header, required_org_id, minimum_required_role=None):
+    def validate_access_token_and_get_user_with_org_by_all_permissions(authorization_header, required_org_id, permissions=None):
         access_token = _extract_token_from_authorization_header(authorization_header)
         user = _validate_access_token_and_get_user(access_token, token_verification_metadata)
-        org_member_info = validate_all_permissions_and_get_org(user, required_org_id, minimum_required_role)
+        org_member_info = validate_all_permissions_and_get_org(user, required_org_id, permissions)
         return UserAndOrgMemberInfo(user, org_member_info)
 
     return validate_access_token_and_get_user_with_org_by_all_permissions

--- a/propelauth_py/errors.py
+++ b/propelauth_py/errors.py
@@ -54,3 +54,7 @@ class ForbiddenException(Exception):
     @staticmethod
     def user_doesnt_have_required_role():
         return ForbiddenException("User doesn't have required role")
+
+    @staticmethod
+    def user_doesnt_have_required_permission():
+        return ForbiddenException("User doesn't have required permission")

--- a/propelauth_py/errors.py
+++ b/propelauth_py/errors.py
@@ -39,17 +39,6 @@ class UnauthorizedException(Exception):
         return UnauthorizedException("Invalid payload in token")
 
 
-class UnexpectedException(Exception):
-    def __init__(self, message):
-        self.message = message
-
-    @staticmethod
-    def invalid_minimum_required_role():
-        return UnexpectedException(
-            "minimum_required_role must be one of UserRole.Owner, UserRole.Admin, UserRole.Member, or None"
-        )
-
-
 class ForbiddenException(Exception):
     def __init__(self, message):
         self.message = message
@@ -63,5 +52,5 @@ class ForbiddenException(Exception):
         return ForbiddenException("User is not a member of org {}".format(org_id))
 
     @staticmethod
-    def user_less_than_minimum_role():
-        return ForbiddenException("User's role in org doesn't meet minimum required role")
+    def user_doesnt_have_required_role():
+        return ForbiddenException("User doesn't have required role")

--- a/propelauth_py/user.py
+++ b/propelauth_py/user.py
@@ -15,11 +15,11 @@ class User:
 
 
 class OrgMemberInfo:
-    def __init__(self, org_id, org_name, user_assigned_role, user_roles, user_permissions):
+    def __init__(self, org_id, org_name, user_assigned_role, user_inherited_roles_plus_current_role, user_permissions):
         self.org_id = org_id
         self.org_name = org_name
         self.user_assigned_role = user_assigned_role
-        self.user_roles = user_roles
+        self.user_inherited_roles_plus_current_role = user_inherited_roles_plus_current_role
         self.user_permissions = user_permissions
 
     def __eq__(self, other):
@@ -29,13 +29,25 @@ class OrgMemberInfo:
                    self.user_assigned_role == other.user_assigned_role
         return False
     
-    def can_do_role(self, role):
-        """returns true if the user can act as the role"""
-        return role in self.user_roles
+    def user_is_role(self, role):
+        """returns true if the user is the role"""
+        return role == self.user_assigned_role
     
-    def has_permission(self, permission):
+    def user_is_at_least_role(self, role):
+        """returns true if the user can act as the role"""
+        return role in self.user_inherited_roles_plus_current_role
+    
+    def user_has_permission(self, permission):
         """returns true if user has the permission"""
         return permission in self.user_permissions
+
+    def user_has_all_permissions(self, permissions):
+        """returns true if user has the all the permissions listed"""
+        for permission in permissions:
+            if not self.user_has_permission(permission):
+                return False
+        
+        return True
 
 
 class UserAndOrgMemberInfo:
@@ -56,7 +68,7 @@ def _to_org_member_info(org_id_to_org_member_info_json):
                 org_id=org_member_info_json["org_id"],
                 org_name=org_member_info_json["org_name"],
                 user_assigned_role=user_assigned_role,
-                user_roles=org_member_info_json["user_roles"],
+                user_inherited_roles_plus_current_role=org_member_info_json["inherited_user_roles_plus_current_role"],
                 user_permissions=org_member_info_json["user_permissions"],
             )
     return org_id_to_org_member_info

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -24,10 +24,13 @@ def random_org_id():
 
 
 def random_org(user_role_str):
+    # represents the incoming JSON from the auth server
     return {
         "org_id": random_org_id(),
         "org_name": str(uuid4()),
-        "user_role": user_role_str
+        "user_role": user_role_str,
+        "user_roles": [user_role_str],
+        "user_permissions": [],
     }
 
 

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -29,7 +29,7 @@ def random_org(user_role_str):
         "org_id": random_org_id(),
         "org_name": str(uuid4()),
         "user_role": user_role_str,
-        "user_roles": [user_role_str],
+        "inherited_user_roles_plus_current_role": [user_role_str],
         "user_permissions": [],
     }
 

--- a/tests/test_auth_fns.py
+++ b/tests/test_auth_fns.py
@@ -1,0 +1,81 @@
+import pytest
+
+from propelauth_py.errors import ForbiddenException
+from tests.auth_helpers import create_access_token, orgs_to_org_id_map, random_org, random_user_id
+
+def test_validate_minimum_org_role_and_get_org(auth, rsa_keys):
+    user_id = random_user_id()
+    org = random_org("Admin")
+    org["inherited_user_roles_plus_current_role"] = ["Admin", "Member"]
+    org_id_to_org_member_info = orgs_to_org_id_map([org])
+    access_token = create_access_token({
+        "user_id": user_id,
+        "org_id_to_org_member_info": org_id_to_org_member_info
+    }, rsa_keys.private_pem)
+
+    try:
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, org["org_id"], "Admin")
+    except Exception as exc:
+        assert False, f"'validate_access_token_and_get_user_with_org_by_minimum_role with Admin' raised an exception {exc}"
+
+    try:
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, org["org_id"], "Member")
+    except Exception as exc:
+        assert False, f"'validate_access_token_and_get_user_with_org_by_minimum_role with Member' raised an exception {exc}"
+
+
+def test_validate_exact_org_role_and_get_org(auth, rsa_keys):
+    user_id = random_user_id()
+    org = random_org("Admin")
+    org["inherited_user_roles_plus_current_role"] = ["Admin", "Member"]
+    org_id_to_org_member_info = orgs_to_org_id_map([org])
+    access_token = create_access_token({
+        "user_id": user_id,
+        "org_id_to_org_member_info": org_id_to_org_member_info
+    }, rsa_keys.private_pem)
+
+    try:
+        auth.validate_access_token_and_get_user_with_org_by_exact_role("Bearer " + access_token, org["org_id"], "Admin")
+    except Exception as exc:
+        assert False, f"'validate_access_token_and_get_user_with_org_by_exact_role with Admin' raised an exception {exc}"
+
+    with pytest.raises(ForbiddenException):
+        auth.validate_access_token_and_get_user_with_org_by_exact_role("Bearer " + access_token, org["org_id"], "Member")
+
+def test_validate_permission_and_get_org(auth, rsa_keys):
+    user_id = random_user_id()
+    org = random_org("Admin")
+    org["user_permissions"] = ["read", "write"]
+    org_id_to_org_member_info = orgs_to_org_id_map([org])
+    access_token = create_access_token({
+        "user_id": user_id,
+        "org_id_to_org_member_info": org_id_to_org_member_info
+    }, rsa_keys.private_pem)
+
+    try:
+        auth.validate_access_token_and_get_user_with_org_by_permission("Bearer " + access_token, org["org_id"], "read")
+    except Exception as exc:
+        assert False, f"'validate_access_token_and_get_user_with_org_by_permission with read' raised an exception {exc}"
+
+    with pytest.raises(ForbiddenException):
+        auth.validate_access_token_and_get_user_with_org_by_permission("Bearer " + access_token, org["org_id"], "delete")
+
+
+def test_validate_all_permissions_and_get_org(auth, rsa_keys):
+    user_id = random_user_id()
+    org = random_org("Admin")
+    org["user_permissions"] = ["read", "write"]
+    org_id_to_org_member_info = orgs_to_org_id_map([org])
+    access_token = create_access_token({
+        "user_id": user_id,
+        "org_id_to_org_member_info": org_id_to_org_member_info
+    }, rsa_keys.private_pem)
+
+    try:
+        auth.validate_access_token_and_get_user_with_org_by_all_permissions("Bearer " + access_token, org["org_id"], ["read", "write"])
+    except Exception as exc:
+        assert False, f"'validate_access_token_and_get_user_with_org_by_all_permissions with read, write' raised an exception {exc}"
+
+    with pytest.raises(ForbiddenException):
+        auth.validate_access_token_and_get_user_with_org_by_all_permissions("Bearer " + access_token, org["org_id"], ["read", "write", "delete"])
+

--- a/tests/test_require_org_member.py
+++ b/tests/test_require_org_member.py
@@ -4,7 +4,6 @@ import pytest
 
 from propelauth_py import UnauthorizedException
 from propelauth_py.errors import ForbiddenException
-from propelauth_py.user import UserRole
 from tests.auth_helpers import create_access_token, orgs_to_org_id_map, random_org, random_user_id, random_org_id
 from tests.conftest import HTTP_BASE_AUTH_URL, generate_rsa_keys
 
@@ -46,7 +45,7 @@ def test_validate_org_member_with_auth_and_org_member(auth, rsa_keys):
     assert user_and_org.user.user_id == user_id
     assert user_and_org.org_member_info.org_id == org["org_id"]
     assert user_and_org.org_member_info.org_name == org["org_name"]
-    assert user_and_org.org_member_info.user_role == UserRole.Owner
+    assert user_and_org.org_member_info.user_assigned_role == "Owner"
 
 
 def test_validate_org_member_with_auth_but_wrong_org_id(auth, rsa_keys):
@@ -75,7 +74,7 @@ def test_validate_org_member_with_auth_but_no_permission(auth, rsa_keys):
 
     # Require at least admin, but the user is a member
     with pytest.raises(ForbiddenException):
-        auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"], UserRole.Admin)
+        auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"], "Admin")
 
 
 def test_validate_org_member_with_auth_with_permission(auth, rsa_keys):
@@ -87,13 +86,12 @@ def test_validate_org_member_with_auth_with_permission(auth, rsa_keys):
         "org_id_to_org_member_info": org_id_to_org_member_info
     }, rsa_keys.private_pem)
 
-    user_and_org = auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"],
-                                                                    UserRole.Admin)
+    user_and_org = auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"], "Admin")
 
     assert user_and_org.user.user_id == user_id
     assert user_and_org.org_member_info.org_id == org["org_id"]
     assert user_and_org.org_member_info.org_name == org["org_name"]
-    assert user_and_org.org_member_info.user_role == UserRole.Admin
+    assert user_and_org.org_member_info.user_assigned_role == "Admin"
 
 
 def test_validate_org_member_with_bad_header(auth, rsa_keys):

--- a/tests/test_require_org_member.py
+++ b/tests/test_require_org_member.py
@@ -12,14 +12,14 @@ def test_validate_without_auth(auth, rsa_keys):
     required_org_id = random_org_id()
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org(None, required_org_id)
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role(None, required_org_id)
 
 
 def test_validate_without_auth_2(auth, rsa_keys):
     required_org_id = random_org_id()
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org("", required_org_id)
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("", required_org_id)
 
 
 def test_validate_org_member_with_auth_but_no_org_membership(auth, rsa_keys):
@@ -28,7 +28,7 @@ def test_validate_org_member_with_auth_but_no_org_membership(auth, rsa_keys):
     access_token = create_access_token({"user_id": user_id}, rsa_keys.private_pem)
 
     with pytest.raises(ForbiddenException):
-        auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, required_org_id)
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, required_org_id)
 
 
 def test_validate_org_member_with_auth_and_org_member(auth, rsa_keys):
@@ -40,7 +40,7 @@ def test_validate_org_member_with_auth_and_org_member(auth, rsa_keys):
         "org_id_to_org_member_info": org_id_to_org_member_info
     }, rsa_keys.private_pem)
 
-    user_and_org = auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"])
+    user_and_org = auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, org["org_id"])
 
     assert user_and_org.user.user_id == user_id
     assert user_and_org.org_member_info.org_id == org["org_id"]
@@ -60,7 +60,7 @@ def test_validate_org_member_with_auth_but_wrong_org_id(auth, rsa_keys):
     # Pass wrong org_id as required
     wrong_org_id = random_org_id()
     with pytest.raises(ForbiddenException):
-        auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, wrong_org_id)
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, wrong_org_id)
 
 
 def test_validate_org_member_with_auth_but_no_permission(auth, rsa_keys):
@@ -74,7 +74,7 @@ def test_validate_org_member_with_auth_but_no_permission(auth, rsa_keys):
 
     # Require at least admin, but the user is a member
     with pytest.raises(ForbiddenException):
-        auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"], "Admin")
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, org["org_id"], "Admin")
 
 
 def test_validate_org_member_with_auth_with_permission(auth, rsa_keys):
@@ -86,7 +86,7 @@ def test_validate_org_member_with_auth_with_permission(auth, rsa_keys):
         "org_id_to_org_member_info": org_id_to_org_member_info
     }, rsa_keys.private_pem)
 
-    user_and_org = auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"], "Admin")
+    user_and_org = auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, org["org_id"], "Admin")
 
     assert user_and_org.user.user_id == user_id
     assert user_and_org.org_member_info.org_id == org["org_id"]
@@ -104,14 +104,14 @@ def test_validate_org_member_with_bad_header(auth, rsa_keys):
     }, rsa_keys.private_pem)
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org("token " + access_token, org["org_id"])
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("token " + access_token, org["org_id"])
 
 
 def test_validate_org_member_with_wrong_token(auth, rsa_keys):
     required_org_id = random_org_id()
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org("Bearer whatisthis", required_org_id)
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer whatisthis", required_org_id)
 
 
 def test_validate_org_member_with_expired_token(auth, rsa_keys):
@@ -124,7 +124,7 @@ def test_validate_org_member_with_expired_token(auth, rsa_keys):
     }, rsa_keys.private_pem, expires_in=timedelta(minutes=-1))
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org("Bearer" + access_token, org["org_id"])
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer" + access_token, org["org_id"])
 
 
 def test_validate_org_member_with_bad_issuer(auth, rsa_keys):
@@ -137,7 +137,7 @@ def test_validate_org_member_with_bad_issuer(auth, rsa_keys):
     }, rsa_keys.private_pem, issuer=HTTP_BASE_AUTH_URL)
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org("Bearer" + access_token, org["org_id"])
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer" + access_token, org["org_id"])
 
 
 def test_validate_org_member_with_wrong_key(auth, rsa_keys):
@@ -152,4 +152,4 @@ def test_validate_org_member_with_wrong_key(auth, rsa_keys):
     }, incorrect_rsa_keys.private_pem, issuer=HTTP_BASE_AUTH_URL)
 
     with pytest.raises(UnauthorizedException):
-        auth.validate_access_token_and_get_user_with_org("Bearer " + access_token, org["org_id"])
+        auth.validate_access_token_and_get_user_with_org_by_minimum_role("Bearer " + access_token, org["org_id"])

--- a/tests/test_user_conversion.py
+++ b/tests/test_user_conversion.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from propelauth_py.user import _to_user, User, OrgMemberInfo, UserRole
+from propelauth_py.user import _to_user, User, OrgMemberInfo
 
 
 def test_to_user_without_orgs():
@@ -16,16 +16,22 @@ def test_to_user():
         "org_id": str(uuid4()),
         "org_name": "orgA",
         "user_role": "Owner",
+        "user_roles": ["Owner", "Admin", "Member"],
+        "user_permissions": ["View", "Edit", "Delete"],
     }
     org_b = {
         "org_id": str(uuid4()),
         "org_name": "orgB",
         "user_role": "Admin",
+        "user_roles": ["Admin", "Member"],
+        "user_permissions": ["View", "Edit"],
     }
     org_c = {
         "org_id": str(uuid4()),
         "org_name": "orgC",
         "user_role": "Member",
+        "user_roles": ["Member"],
+        "user_permissions": ["View"],
     }
     org_id_to_org_member_info = {
         org_a["org_id"]: org_a,
@@ -39,17 +45,23 @@ def test_to_user():
         org_a["org_id"]: OrgMemberInfo(
             org_id=org_a["org_id"],
             org_name=org_a["org_name"],
-            user_role=UserRole.Owner,
+            user_assigned_role="Owner",
+            user_roles=["Owner", "Admin", "Member"],
+            user_permissions=["View", "Edit", "Delete"],
         ),
         org_b["org_id"]: OrgMemberInfo(
             org_id=org_b["org_id"],
             org_name=org_b["org_name"],
-            user_role=UserRole.Admin,
+            user_assigned_role="Admin",
+            user_roles=["Admin", "Member"],
+            user_permissions=["View", "Edit"],
         ),
         org_c["org_id"]: OrgMemberInfo(
             org_id=org_c["org_id"],
             org_name=org_c["org_name"],
-            user_role=UserRole.Member,
+            user_assigned_role="Member",
+            user_roles=["Member"],
+            user_permissions=["View"],
         )
     }
     expected_user = User(user_id, expected_org_id_to_org_member_info)

--- a/tests/test_user_conversion.py
+++ b/tests/test_user_conversion.py
@@ -16,21 +16,21 @@ def test_to_user():
         "org_id": str(uuid4()),
         "org_name": "orgA",
         "user_role": "Owner",
-        "user_roles": ["Owner", "Admin", "Member"],
+        "inherited_user_roles_plus_current_role": ["Owner", "Admin", "Member"],
         "user_permissions": ["View", "Edit", "Delete"],
     }
     org_b = {
         "org_id": str(uuid4()),
         "org_name": "orgB",
         "user_role": "Admin",
-        "user_roles": ["Admin", "Member"],
+        "inherited_user_roles_plus_current_role": ["Admin", "Member"],
         "user_permissions": ["View", "Edit"],
     }
     org_c = {
         "org_id": str(uuid4()),
         "org_name": "orgC",
         "user_role": "Member",
-        "user_roles": ["Member"],
+        "inherited_user_roles_plus_current_role": ["Member"],
         "user_permissions": ["View"],
     }
     org_id_to_org_member_info = {
@@ -46,21 +46,21 @@ def test_to_user():
             org_id=org_a["org_id"],
             org_name=org_a["org_name"],
             user_assigned_role="Owner",
-            user_roles=["Owner", "Admin", "Member"],
+            user_inherited_roles_plus_current_role=["Owner", "Admin", "Member"],
             user_permissions=["View", "Edit", "Delete"],
         ),
         org_b["org_id"]: OrgMemberInfo(
             org_id=org_b["org_id"],
             org_name=org_b["org_name"],
             user_assigned_role="Admin",
-            user_roles=["Admin", "Member"],
+            user_inherited_roles_plus_current_role=["Admin", "Member"],
             user_permissions=["View", "Edit"],
         ),
         org_c["org_id"]: OrgMemberInfo(
             org_id=org_c["org_id"],
             org_name=org_c["org_name"],
             user_assigned_role="Member",
-            user_roles=["Member"],
+            user_inherited_roles_plus_current_role=["Member"],
             user_permissions=["View"],
         )
     }


### PR DESCRIPTION
Roles and Permissions are now customizable in the PropelAuth backend, and this new change handles that. A user still has a single role, but now we give a list of all roles that role "inherits" from, plus a list of permissions associated with that role. These are populated in OrgMemberInfo.

There are three basic attributes to handle these changes, alongside some associated functions:

- use_role is now **user_assigned_role**. It's now a straight string instead of an enum. Check for this exact role with **user_is_role**() method.
- **user_inherited_roles_plus_current_role** is a list of all roles that this user "inherits". Instead of checking roles with < and >, you should check for the existence of the role in this list using the new **user_is_at_least_role**() method.
- **user_permissions** is a list of all permissions this user has. These are the four hardcoded permissions, e.g. SAML, deleting users, etc. Check for these permissions with the **user_has_permission**() and **user_has_all_permissions**() methods.

Also included with these changes are four new validation functions to that will throw appropriate errors, plus four wrappers to work with access tokens.

Other changes in relation to customizable RBAC roles:

- Removed UserRole enum, the concept of minimum required roles, and the associated UnexpectedException.
- New exception: ForbiddenException.user_doesnt_have_required_permission

The basic function **validate_access_token_and_get_user_with_org** has been changed to **validate_access_token_and_get_user_with_org_by_minimum_role**. If you do nothing else with your code, update this.