### PR TITLE
add user impersonation, and user and org metadata

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -5,8 +5,8 @@ from propelauth_py.api import _fetch_token_verification_metadata, TokenVerificat
     _fetch_user_metadata_by_email, _fetch_user_metadata_by_username, _fetch_batch_user_metadata_by_user_ids, \
     _fetch_batch_user_metadata_by_emails, _fetch_batch_user_metadata_by_usernames, OrgQueryOrderBy, UserQueryOrderBy, \
     _fetch_org, _fetch_org_by_query, _fetch_users_by_query, _fetch_users_in_org, _create_user, _update_user_email, \
-    _update_user_metadata, _create_magic_link, _migrate_user_from_external_source, _create_org, _add_user_to_org, \
-    _delete_user, _disable_user, _enable_user, _allow_org_to_setup_saml_connection, \
+    _update_user_metadata, _create_magic_link, _migrate_user_from_external_source, _create_org, _update_org_metadata, \
+    _add_user_to_org, _delete_user, _disable_user, _enable_user, _allow_org_to_setup_saml_connection, \
     _disallow_org_to_setup_saml_connection
 from propelauth_py.auth_fns import wrap_validate_access_token_and_get_user, \
     wrap_validate_access_token_and_get_user_with_org, \
@@ -50,6 +50,7 @@ Auth = namedtuple("Auth", [
     "create_magic_link",
     "migrate_user_from_external_source",
     "create_org",
+    "update_org_metadata",
     "add_user_to_org",
     "delete_user",
     "disable_user",
@@ -104,8 +105,8 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
     def update_user_email(user_id, new_email, require_email_confirmation):
         return _update_user_email(auth_url, api_key, user_id, new_email, require_email_confirmation)
 
-    def update_user_metadata(user_id, username=None, first_name=None, last_name=None):
-        return _update_user_metadata(auth_url, api_key, user_id, username, first_name, last_name)
+    def update_user_metadata(user_id, username=None, first_name=None, last_name=None, metadata=None):
+        return _update_user_metadata(auth_url, api_key, user_id, username, first_name, last_name, metadata)
 
     def create_magic_link(email, redirect_to_url=None, expires_in_hours=None, create_new_user_if_one_doesnt_exist=None):
         return _create_magic_link(auth_url, api_key, email, redirect_to_url, expires_in_hours,
@@ -122,6 +123,9 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
 
     def create_org(name):
         return _create_org(auth_url, api_key, name)
+
+    def update_org_metadata(org_id, name=None, can_setup_saml=None, metadata=None):
+        return _update_org_metadata(auth_url, api_key, org_id, name, can_setup_saml, metadata)
 
     def add_user_to_org(user_id, org_id, role):
         return _add_user_to_org(auth_url, api_key, user_id, org_id, role)
@@ -193,6 +197,7 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
         create_magic_link=create_magic_link,
         migrate_user_from_external_source=migrate_user_from_external_source,
         create_org=create_org,
+        update_org_metadata=update_org_metadata,
         add_user_to_org=add_user_to_org,
         enable_user=enable_user,
         disable_user=disable_user,

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -226,7 +226,7 @@ def _create_user(auth_url, api_key, email, email_confirmed, send_email_to_confir
     return response.json()
 
 
-def _update_user_metadata(auth_url, api_key, user_id, username=None, first_name=None, last_name=None):
+def _update_user_metadata(auth_url, api_key, user_id, username=None, first_name=None, last_name=None, metadata=None):
     if not _is_valid_id(user_id):
         return False
 
@@ -238,6 +238,8 @@ def _update_user_metadata(auth_url, api_key, user_id, username=None, first_name=
         json["first_name"] = first_name
     if last_name is not None:
         json["last_name"] = last_name
+    if metadata is not None:
+        json["metadata"] = metadata
 
     response = requests.put(url, json=json, auth=_ApiKeyAuth(api_key))
     if response.status_code == 401:
@@ -338,6 +340,32 @@ def _create_org(auth_url, api_key, name):
         raise RuntimeError("Unknown error when creating an org")
 
     return response.json()
+
+
+def _update_org_metadata(auth_url, api_key, org_id, name=None, can_setup_saml=None, metadata=None):
+    if not _is_valid_id(org_id):
+        return False
+
+    url = auth_url + "/api/backend/v1/org/{}".format(org_id)
+    json = {}
+    if name is not None:
+        json["name"] = name
+    if can_setup_saml is not None:
+        json["can_setup_saml"] = can_setup_saml
+    if metadata is not None:
+        json["metadata"] = metadata
+
+    response = requests.put(url, json=json, auth=_ApiKeyAuth(api_key))
+    if response.status_code == 401:
+        raise ValueError("api_key is incorrect")
+    elif response.status_code == 400:
+        raise UpdateUserMetadataException(response.json())
+    elif response.status_code == 404:
+        return False
+    elif not response.ok:
+        raise RuntimeError("Unknown error when updating org metadata")
+
+    return True
 
 
 def _add_user_to_org(auth_url, api_key, user_id, org_id, role):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="propelauth-py",
-    version="3.0.0",
+    version="3.1.0",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/auth_helpers.py
+++ b/tests/auth_helpers.py
@@ -28,6 +28,7 @@ def random_org(user_role_str, permissions=None):
     return {
         "org_id": random_org_id(),
         "org_name": str(uuid4()),
+        "org_metadata": {},
         "user_role": user_role_str,
         "inherited_user_roles_plus_current_role": [user_role_str],
         "user_permissions": [] if permissions is None else permissions,

--- a/tests/test_user_conversion.py
+++ b/tests/test_user_conversion.py
@@ -15,6 +15,7 @@ def test_to_user():
     org_a = {
         "org_id": str(uuid4()),
         "org_name": "orgA",
+        "org_metadata": {"org_metadata_key_a": "org_metadata_value_a"},
         "user_role": "Owner",
         "inherited_user_roles_plus_current_role": ["Owner", "Admin", "Member"],
         "user_permissions": ["View", "Edit", "Delete"],
@@ -22,6 +23,7 @@ def test_to_user():
     org_b = {
         "org_id": str(uuid4()),
         "org_name": "orgB",
+        "org_metadata": {"org_metadata_key_b": "org_metadata_value_b"},
         "user_role": "Admin",
         "inherited_user_roles_plus_current_role": ["Admin", "Member"],
         "user_permissions": ["View", "Edit"],
@@ -29,6 +31,7 @@ def test_to_user():
     org_c = {
         "org_id": str(uuid4()),
         "org_name": "orgC",
+        "org_metadata": {"org_metadata_key_c": "org_metadata_value_c"},
         "user_role": "Member",
         "inherited_user_roles_plus_current_role": ["Member"],
         "user_permissions": ["View"],
@@ -45,6 +48,7 @@ def test_to_user():
         org_a["org_id"]: OrgMemberInfo(
             org_id=org_a["org_id"],
             org_name=org_a["org_name"],
+            org_metadata=org_a["org_metadata"],
             user_assigned_role="Owner",
             user_inherited_roles_plus_current_role=["Owner", "Admin", "Member"],
             user_permissions=["View", "Edit", "Delete"],
@@ -52,6 +56,7 @@ def test_to_user():
         org_b["org_id"]: OrgMemberInfo(
             org_id=org_b["org_id"],
             org_name=org_b["org_name"],
+            org_metadata=org_b["org_metadata"],
             user_assigned_role="Admin",
             user_inherited_roles_plus_current_role=["Admin", "Member"],
             user_permissions=["View", "Edit"],
@@ -59,6 +64,7 @@ def test_to_user():
         org_c["org_id"]: OrgMemberInfo(
             org_id=org_c["org_id"],
             org_name=org_c["org_name"],
+            org_metadata=org_c["org_metadata"],
             user_assigned_role="Member",
             user_inherited_roles_plus_current_role=["Member"],
             user_permissions=["View"],


### PR DESCRIPTION
The User now has an impersonator_user_id field. This is the UUID of the other user that is impersonating this user. It will be None if impersonation is not happening (which it normally isn't).

Metadata is private, user-specific metadata which can be set via the regular update_metadata endpoint. The user will never see or use this metadata, it's just for the PropelAuth customer.

The Org objects have org_metadata. Much like user metadata, this is a private field.

The metadata objects are simple hashes with a string key and any JSON object for the value.