### PR TITLE
Return the JSON response within _create_access_token (#11)

### DIFF
--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -339,6 +339,8 @@ def _create_access_token(auth_url, api_key, user_id, duration_in_minutes):
     elif not response.ok:
         raise RuntimeError("Unknown error when creating access token")
 
+    return response.json()
+
 
 def _migrate_user_from_external_source(auth_url, api_key, email, email_confirmed,
                                        existing_user_id=None, existing_password_hash=None,


### PR DESCRIPTION
Resolves #11.

Return the generated access token to the caller when unit testing via `create_access_token`. 