### PR TITLE
new endpoints - api keys, org control, and more

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -8,9 +8,9 @@ from propelauth_py.api import _fetch_token_verification_metadata, TokenVerificat
     _update_user_metadata, _create_magic_link, _migrate_user_from_external_source, _create_org, _update_org_metadata, \
     _add_user_to_org, _delete_user, _disable_user, _enable_user, _allow_org_to_setup_saml_connection, \
     _disallow_org_to_setup_saml_connection, _update_user_password, _create_access_token, _disable_user_2fa, \
-    _enable_user_can_create_orgs, _disable_user_can_create_orgs, _fetch_end_user_api_key, \
-    _fetch_current_end_user_api_keys, _fetch_archived_end_user_api_keys, _create_end_user_api_key, \
-    _update_end_user_api_key, _delete_end_user_api_key, _validate_end_user_api_key
+    _enable_user_can_create_orgs, _disable_user_can_create_orgs, _fetch_api_key, \
+    _fetch_current_api_keys, _fetch_archived_api_keys, _create_api_key, \
+    _update_api_key, _delete_api_key, _validate_api_key
 from propelauth_py.auth_fns import wrap_validate_access_token_and_get_user, \
     wrap_validate_access_token_and_get_user_with_org, \
     wrap_validate_access_token_and_get_user_with_org_by_minimum_role, \
@@ -65,142 +65,142 @@ Auth = namedtuple("Auth", [
     "disable_user_can_create_orgs",
     "allow_org_to_setup_saml_connection",
     "disallow_org_to_setup_saml_connection",
-    "fetch_end_user_api_key",
-    "fetch_current_end_user_api_keys",
-    "fetch_archived_end_user_api_keys",
-    "create_end_user_api_key",
-    "update_end_user_api_key",
-    "delete_end_user_api_key",
-    "validate_end_user_api_key",
+    "fetch_api_key",
+    "fetch_current_api_keys",
+    "fetch_archived_api_keys",
+    "create_api_key",
+    "update_api_key",
+    "delete_api_key",
+    "validate_api_key",
 ])
 
 
-def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: TokenVerificationMetadata = None) -> Auth:
+def init_base_auth(auth_url: str, integration_api_key: str, token_verification_metadata: TokenVerificationMetadata = None) -> Auth:
     """Fetches metadata required to validate access tokens and returns auth decorators and utilities"""
     auth_url = _validate_url(auth_url)
-    token_verification_metadata = _fetch_token_verification_metadata(auth_url, api_key, token_verification_metadata)
+    token_verification_metadata = _fetch_token_verification_metadata(auth_url, integration_api_key, token_verification_metadata)
 
     def fetch_user_metadata_by_user_id(user_id, include_orgs=False):
-        return _fetch_user_metadata_by_user_id(auth_url, api_key, user_id, include_orgs)
+        return _fetch_user_metadata_by_user_id(auth_url, integration_api_key, user_id, include_orgs)
 
     def fetch_user_metadata_by_email(email, include_orgs=False):
-        return _fetch_user_metadata_by_email(auth_url, api_key, email, include_orgs)
+        return _fetch_user_metadata_by_email(auth_url, integration_api_key, email, include_orgs)
 
     def fetch_user_metadata_by_username(username, include_orgs=False):
-        return _fetch_user_metadata_by_username(auth_url, api_key, username, include_orgs)
+        return _fetch_user_metadata_by_username(auth_url, integration_api_key, username, include_orgs)
 
     def fetch_batch_user_metadata_by_user_ids(user_ids, include_orgs=False):
-        return _fetch_batch_user_metadata_by_user_ids(auth_url, api_key, user_ids, include_orgs)
+        return _fetch_batch_user_metadata_by_user_ids(auth_url, integration_api_key, user_ids, include_orgs)
 
     def fetch_batch_user_metadata_by_emails(emails, include_orgs=False):
-        return _fetch_batch_user_metadata_by_emails(auth_url, api_key, emails, include_orgs)
+        return _fetch_batch_user_metadata_by_emails(auth_url, integration_api_key, emails, include_orgs)
 
     def fetch_batch_user_metadata_by_usernames(usernames, include_orgs=False):
-        return _fetch_batch_user_metadata_by_usernames(auth_url, api_key, usernames, include_orgs)
+        return _fetch_batch_user_metadata_by_usernames(auth_url, integration_api_key, usernames, include_orgs)
 
     def fetch_org(org_id):
-        return _fetch_org(auth_url, api_key, org_id)
+        return _fetch_org(auth_url, integration_api_key, org_id)
 
     def fetch_org_by_query(page_size=10, page_number=0, order_by=OrgQueryOrderBy.CREATED_AT_ASC):
-        return _fetch_org_by_query(auth_url, api_key, page_size, page_number, order_by)
+        return _fetch_org_by_query(auth_url, integration_api_key, page_size, page_number, order_by)
 
     def fetch_users_by_query(page_size=10, page_number=0, order_by=UserQueryOrderBy.CREATED_AT_ASC,
                              email_or_username=None, include_orgs=False):
-        return _fetch_users_by_query(auth_url, api_key, page_size, page_number, order_by, email_or_username,
+        return _fetch_users_by_query(auth_url, integration_api_key, page_size, page_number, order_by, email_or_username,
                                      include_orgs)
 
     def fetch_users_in_org(org_id, page_size=10, page_number=0, include_orgs=False):
-        return _fetch_users_in_org(auth_url, api_key, org_id, page_size, page_number, include_orgs)
+        return _fetch_users_in_org(auth_url, integration_api_key, org_id, page_size, page_number, include_orgs)
 
     def create_user(email, email_confirmed=False, send_email_to_confirm_email_address=True,
                     ask_user_to_update_password_on_login=False,
                     password=None, username=None, first_name=None, last_name=None):
-        return _create_user(auth_url, api_key, email, email_confirmed, send_email_to_confirm_email_address,
+        return _create_user(auth_url, integration_api_key, email, email_confirmed, send_email_to_confirm_email_address,
                             ask_user_to_update_password_on_login,
                             password, username, first_name, last_name)
 
     def update_user_email(user_id, new_email, require_email_confirmation):
-        return _update_user_email(auth_url, api_key, user_id, new_email, require_email_confirmation)
+        return _update_user_email(auth_url, integration_api_key, user_id, new_email, require_email_confirmation)
 
     def update_user_metadata(user_id, username=None, first_name=None, last_name=None, metadata=None):
-        return _update_user_metadata(auth_url, api_key, user_id, username, first_name, last_name, metadata)
+        return _update_user_metadata(auth_url, integration_api_key, user_id, username, first_name, last_name, metadata)
 
     def update_user_password(user_id, password, ask_user_to_update_password_on_login=False):
-        return _update_user_password(auth_url, api_key, user_id, password, ask_user_to_update_password_on_login)
+        return _update_user_password(auth_url, integration_api_key, user_id, password, ask_user_to_update_password_on_login)
 
     def create_magic_link(email, redirect_to_url=None, expires_in_hours=None, create_new_user_if_one_doesnt_exist=None):
-        return _create_magic_link(auth_url, api_key, email, redirect_to_url, expires_in_hours,
+        return _create_magic_link(auth_url, integration_api_key, email, redirect_to_url, expires_in_hours,
                                   create_new_user_if_one_doesnt_exist)
 
     def create_access_token(user_id, duration_in_minutes):
-        return _create_access_token(auth_url, api_key, user_id, duration_in_minutes)
+        return _create_access_token(auth_url, integration_api_key, user_id, duration_in_minutes)
 
     def migrate_user_from_external_source(email, email_confirmed,
                                           existing_user_id=None, existing_password_hash=None,
                                           existing_mfa_base32_encoded_secret=None,
                                           ask_user_to_update_password_on_login=False,
                                           enabled=None, first_name=None, last_name=None, username=None):
-        return _migrate_user_from_external_source(auth_url, api_key, email, email_confirmed,
+        return _migrate_user_from_external_source(auth_url, integration_api_key, email, email_confirmed,
                                                   existing_user_id, existing_password_hash,
                                                   existing_mfa_base32_encoded_secret,
                                                   ask_user_to_update_password_on_login,
                                                   enabled, first_name, last_name, username)
 
     def create_org(name):
-        return _create_org(auth_url, api_key, name)
+        return _create_org(auth_url, integration_api_key, name)
 
     def update_org_metadata(org_id, name=None, can_setup_saml=None, metadata=None):
-        return _update_org_metadata(auth_url, api_key, org_id, name, can_setup_saml, metadata)
+        return _update_org_metadata(auth_url, integration_api_key, org_id, name, can_setup_saml, metadata)
 
     def add_user_to_org(user_id, org_id, role):
-        return _add_user_to_org(auth_url, api_key, user_id, org_id, role)
+        return _add_user_to_org(auth_url, integration_api_key, user_id, org_id, role)
 
     def delete_user(user_id):
-        return _delete_user(auth_url, api_key, user_id)
+        return _delete_user(auth_url, integration_api_key, user_id)
 
     def disable_user(user_id):
-        return _disable_user(auth_url, api_key, user_id)
+        return _disable_user(auth_url, integration_api_key, user_id)
 
     def enable_user(user_id):
-        return _enable_user(auth_url, api_key, user_id)
+        return _enable_user(auth_url, integration_api_key, user_id)
 
     def disable_user_2fa(user_id):
-        return _disable_user_2fa(auth_url, api_key, user_id)
+        return _disable_user_2fa(auth_url, integration_api_key, user_id)
 
     def enable_user_can_create_orgs(user_id):
-        return _enable_user_can_create_orgs(auth_url, api_key, user_id)
+        return _enable_user_can_create_orgs(auth_url, integration_api_key, user_id)
 
     def disable_user_can_create_orgs(user_id):
-        return _disable_user_can_create_orgs(auth_url, api_key, user_id)
+        return _disable_user_can_create_orgs(auth_url, integration_api_key, user_id)
 
     def allow_org_to_setup_saml_connection(org_id):
-        return _allow_org_to_setup_saml_connection(auth_url, api_key, org_id)
+        return _allow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id)
 
     def disallow_org_to_setup_saml_connection(org_id):
-        return _disallow_org_to_setup_saml_connection(auth_url, api_key, org_id)
+        return _disallow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id)
 
     # functions for end user api keys
-    
-    def fetch_end_user_api_key(end_user_api_key):
-        return _fetch_end_user_api_key(auth_url, api_key, end_user_api_key)
 
-    def fetch_current_end_user_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
-        return _fetch_current_end_user_api_keys(auth_url, api_key, org_id, user_id, user_email, page_size, page_number)
+    def fetch_api_key(api_key):
+        return _fetch_api_key(auth_url, integration_api_key, api_key)
 
-    def fetch_archived_end_user_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
-        return _fetch_archived_end_user_api_keys(auth_url, api_key, org_id, user_id, user_email, page_size, page_number)
+    def fetch_current_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
+        return _fetch_current_api_keys(auth_url, integration_api_key, org_id, user_id, user_email, page_size, page_number)
 
-    def create_end_user_api_key(org_id=None, user_id=None, expires_at_seconds=None, metadata=None):
-        return _create_end_user_api_key(auth_url, api_key, org_id, user_id, expires_at_seconds, metadata)
+    def fetch_archived_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
+        return _fetch_archived_api_keys(auth_url, integration_api_key, org_id, user_id, user_email, page_size, page_number)
 
-    def update_end_user_api_key(end_user_api_key, expires_at_seconds=None, metadata=None):
-        return _update_end_user_api_key(auth_url, api_key, end_user_api_key, expires_at_seconds, metadata)
+    def create_api_key(org_id=None, user_id=None, expires_at_seconds=None, metadata=None):
+        return _create_api_key(auth_url, integration_api_key, org_id, user_id, expires_at_seconds, metadata)
 
-    def delete_end_user_api_key(end_user_api_key):
-        return _delete_end_user_api_key(auth_url, api_key, end_user_api_key)
+    def update_api_key(api_key, expires_at_seconds=None, metadata=None):
+        return _update_api_key(auth_url, integration_api_key, api_key, expires_at_seconds, metadata)
 
-    def validate_end_user_api_key(end_user_api_key):
-        return _validate_end_user_api_key(auth_url, api_key, end_user_api_key)
+    def delete_api_key(api_key):
+        return _delete_api_key(auth_url, integration_api_key, api_key)
+
+    def validate_api_key(api_key):
+        return _validate_api_key(auth_url, integration_api_key, api_key)
 
     validate_access_token_and_get_user = wrap_validate_access_token_and_get_user(token_verification_metadata)
 
@@ -268,11 +268,11 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
         allow_org_to_setup_saml_connection=allow_org_to_setup_saml_connection,
         disallow_org_to_setup_saml_connection=disallow_org_to_setup_saml_connection,
         # api key functions
-        fetch_end_user_api_key=fetch_end_user_api_key,
-        fetch_current_end_user_api_keys=fetch_current_end_user_api_keys,
-        fetch_archived_end_user_api_keys=fetch_archived_end_user_api_keys,
-        create_end_user_api_key=create_end_user_api_key,
-        update_end_user_api_key=update_end_user_api_key,
-        delete_end_user_api_key=delete_end_user_api_key,
-        validate_end_user_api_key=validate_end_user_api_key,
+        fetch_api_key=fetch_api_key,
+        fetch_current_api_keys=fetch_current_api_keys,
+        fetch_archived_api_keys=fetch_archived_api_keys,
+        create_api_key=create_api_key,
+        update_api_key=update_api_key,
+        delete_api_key=delete_api_key,
+        validate_api_key=validate_api_key,
     )

--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -7,7 +7,10 @@ from propelauth_py.api import _fetch_token_verification_metadata, TokenVerificat
     _fetch_org, _fetch_org_by_query, _fetch_users_by_query, _fetch_users_in_org, _create_user, _update_user_email, \
     _update_user_metadata, _create_magic_link, _migrate_user_from_external_source, _create_org, _update_org_metadata, \
     _add_user_to_org, _delete_user, _disable_user, _enable_user, _allow_org_to_setup_saml_connection, \
-    _disallow_org_to_setup_saml_connection, _update_user_password, _create_access_token
+    _disallow_org_to_setup_saml_connection, _update_user_password, _create_access_token, _disable_user_2fa, \
+    _enable_user_can_create_orgs, _disable_user_can_create_orgs, _fetch_end_user_api_key, \
+    _fetch_current_end_user_api_keys, _fetch_archived_end_user_api_keys, _create_end_user_api_key, \
+    _update_end_user_api_key, _delete_end_user_api_key, _validate_end_user_api_key
 from propelauth_py.auth_fns import wrap_validate_access_token_and_get_user, \
     wrap_validate_access_token_and_get_user_with_org, \
     wrap_validate_access_token_and_get_user_with_org_by_minimum_role, \
@@ -57,8 +60,18 @@ Auth = namedtuple("Auth", [
     "delete_user",
     "disable_user",
     "enable_user",
+    "disable_user_2fa",
+    "enable_user_can_create_orgs",
+    "disable_user_can_create_orgs",
     "allow_org_to_setup_saml_connection",
-    "disallow_org_to_setup_saml_connection"
+    "disallow_org_to_setup_saml_connection",
+    "fetch_end_user_api_key",
+    "fetch_current_end_user_api_keys",
+    "fetch_archived_end_user_api_keys",
+    "create_end_user_api_key",
+    "update_end_user_api_key",
+    "delete_end_user_api_key",
+    "validate_end_user_api_key",
 ])
 
 
@@ -151,15 +164,48 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
     def enable_user(user_id):
         return _enable_user(auth_url, api_key, user_id)
 
+    def disable_user_2fa(user_id):
+        return _disable_user_2fa(auth_url, api_key, user_id)
+
+    def enable_user_can_create_orgs(user_id):
+        return _enable_user_can_create_orgs(auth_url, api_key, user_id)
+
+    def disable_user_can_create_orgs(user_id):
+        return _disable_user_can_create_orgs(auth_url, api_key, user_id)
+
     def allow_org_to_setup_saml_connection(org_id):
         return _allow_org_to_setup_saml_connection(auth_url, api_key, org_id)
 
     def disallow_org_to_setup_saml_connection(org_id):
         return _disallow_org_to_setup_saml_connection(auth_url, api_key, org_id)
 
+    # functions for end user api keys
+    
+    def fetch_end_user_api_key(end_user_api_key):
+        return _fetch_end_user_api_key(auth_url, api_key, end_user_api_key)
+
+    def fetch_current_end_user_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
+        return _fetch_current_end_user_api_keys(auth_url, api_key, org_id, user_id, user_email, page_size, page_number)
+
+    def fetch_archived_end_user_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
+        return _fetch_archived_end_user_api_keys(auth_url, api_key, org_id, user_id, user_email, page_size, page_number)
+
+    def create_end_user_api_key(org_id=None, user_id=None, expires_at_seconds=None, metadata=None):
+        return _create_end_user_api_key(auth_url, api_key, org_id, user_id, expires_at_seconds, metadata)
+
+    def update_end_user_api_key(end_user_api_key, expires_at_seconds=None, metadata=None):
+        return _update_end_user_api_key(auth_url, api_key, end_user_api_key, expires_at_seconds, metadata)
+
+    def delete_end_user_api_key(end_user_api_key):
+        return _delete_end_user_api_key(auth_url, api_key, end_user_api_key)
+
+    def validate_end_user_api_key(end_user_api_key):
+        return _validate_end_user_api_key(auth_url, api_key, end_user_api_key)
+
     validate_access_token_and_get_user = wrap_validate_access_token_and_get_user(token_verification_metadata)
 
-    validate_access_token_and_get_user_with_org = wrap_validate_access_token_and_get_user_with_org(token_verification_metadata)
+    validate_access_token_and_get_user_with_org = wrap_validate_access_token_and_get_user_with_org(
+        token_verification_metadata)
 
     validate_access_token_and_get_user_with_org_by_minimum_role = wrap_validate_access_token_and_get_user_with_org_by_minimum_role(
         token_verification_metadata
@@ -216,6 +262,17 @@ def init_base_auth(auth_url: str, api_key: str, token_verification_metadata: Tok
         enable_user=enable_user,
         disable_user=disable_user,
         delete_user=delete_user,
+        disable_user_2fa=disable_user_2fa,
+        enable_user_can_create_orgs=enable_user_can_create_orgs,
+        disable_user_can_create_orgs=disable_user_can_create_orgs,
         allow_org_to_setup_saml_connection=allow_org_to_setup_saml_connection,
         disallow_org_to_setup_saml_connection=disallow_org_to_setup_saml_connection,
+        # api key functions
+        fetch_end_user_api_key=fetch_end_user_api_key,
+        fetch_current_end_user_api_keys=fetch_current_end_user_api_keys,
+        fetch_archived_end_user_api_keys=fetch_archived_end_user_api_keys,
+        create_end_user_api_key=create_end_user_api_key,
+        update_end_user_api_key=update_end_user_api_key,
+        delete_end_user_api_key=delete_end_user_api_key,
+        validate_end_user_api_key=validate_end_user_api_key,
     )

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -735,11 +735,11 @@ class UserQueryOrderBy(str, Enum):
 class _ApiKeyAuth(AuthBase):
     """Attaches API Key Authentication to the given Request object."""
 
-    def __init__(self, api_key):
-        self.api_key = api_key
+    def __init__(self, integration_api_key):
+        self.integration_api_key = integration_api_key
 
     def __call__(self, r):
-        r.headers["Authorization"] = "Bearer " + self.api_key
+        r.headers["Authorization"] = "Bearer " + self.integration_api_key
         return r
 
 

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -567,6 +567,9 @@ def _disallow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id
 
 
 def _fetch_api_key(auth_url, integration_api_key, api_key):
+    if not _is_valid_hex(api_key):
+        return False
+
     url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(api_key)
     response = requests.get(url, auth=_ApiKeyAuth(integration_api_key))
 
@@ -662,6 +665,9 @@ def _create_api_key(auth_url, integration_api_key, org_id, user_id, expires_at_s
 
 
 def _update_api_key(auth_url, integration_api_key, api_key, expires_at_seconds, metadata):
+    if not _is_valid_hex(api_key):
+        return False
+
     url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(api_key)
 
     json = {}
@@ -685,6 +691,9 @@ def _update_api_key(auth_url, integration_api_key, api_key, expires_at_seconds, 
 
 
 def _delete_api_key(auth_url, integration_api_key, api_key):
+    if not _is_valid_hex(api_key):
+        return False
+
     url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(api_key)
     response = requests.delete(url, auth=_ApiKeyAuth(integration_api_key))
 
@@ -701,6 +710,9 @@ def _delete_api_key(auth_url, integration_api_key, api_key):
 
 
 def _validate_api_key(auth_url, integration_api_key, api_key):
+    if not _is_valid_hex(api_key):
+        return False
+
     url = auth_url + "/api/backend/v1/end_user_api_keys"
     json = {"api_key_token": api_key}
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key), json=json)
@@ -761,5 +773,12 @@ def _is_valid_id(identifier):
     try:
         uuid_obj = UUID(identifier, version=4)
         return str(uuid_obj) == identifier
+    except ValueError:
+        return False
+
+def _is_valid_hex(identifier):
+    try:
+        int(identifier, 16)
+        return True
     except ValueError:
         return False

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -14,15 +14,15 @@ TokenVerificationMetadata = namedtuple("TokenVerificationMetadata", [
 ])
 
 
-def _fetch_token_verification_metadata(auth_url: str, api_key: str,
+def _fetch_token_verification_metadata(auth_url: str, integration_api_key: str,
                                        token_verification_metadata: TokenVerificationMetadata):
     if token_verification_metadata is not None:
         return token_verification_metadata
 
     token_verification_metadata_url = auth_url + "/api/v1/token_verification_metadata"
-    response = requests.get(token_verification_metadata_url, auth=_ApiKeyAuth(api_key))
+    response = requests.get(token_verification_metadata_url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise ValueError("Bad request")
     elif response.status_code == 404:
@@ -37,31 +37,31 @@ def _fetch_token_verification_metadata(auth_url: str, api_key: str,
     )
 
 
-def _fetch_user_metadata_by_user_id(auth_url, api_key, user_id, include_orgs=False):
+def _fetch_user_metadata_by_user_id(auth_url, integration_api_key, user_id, include_orgs=False):
     if not _is_valid_id(user_id):
         return None
 
     user_info_url = auth_url + "/api/backend/v1/user/{}".format(user_id)
     query = {"include_orgs": include_orgs}
-    return _fetch_user_metadata_by_query(api_key, user_info_url, query)
+    return _fetch_user_metadata_by_query(integration_api_key, user_info_url, query)
 
 
-def _fetch_user_metadata_by_email(auth_url, api_key, email, include_orgs=False):
+def _fetch_user_metadata_by_email(auth_url, integration_api_key, email, include_orgs=False):
     user_info_url = auth_url + "/api/backend/v1/user/email"
     query = {"include_orgs": include_orgs, "email": email}
-    return _fetch_user_metadata_by_query(api_key, user_info_url, query)
+    return _fetch_user_metadata_by_query(integration_api_key, user_info_url, query)
 
 
-def _fetch_user_metadata_by_username(auth_url, api_key, username, include_orgs=False):
+def _fetch_user_metadata_by_username(auth_url, integration_api_key, username, include_orgs=False):
     user_info_url = auth_url + "/api/backend/v1/user/username"
     query = {"include_orgs": include_orgs, "username": username}
-    return _fetch_user_metadata_by_query(api_key, user_info_url, query)
+    return _fetch_user_metadata_by_query(integration_api_key, user_info_url, query)
 
 
-def _fetch_user_metadata_by_query(api_key, user_info_url, query):
-    response = requests.get(user_info_url, params=_format_params(query), auth=_ApiKeyAuth(api_key))
+def _fetch_user_metadata_by_query(integration_api_key, user_info_url, query):
+    response = requests.get(user_info_url, params=_format_params(query), auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 404:
@@ -72,31 +72,31 @@ def _fetch_user_metadata_by_query(api_key, user_info_url, query):
     return response.json()
 
 
-def _fetch_batch_user_metadata_by_user_ids(auth_url, api_key, user_ids, include_orgs):
+def _fetch_batch_user_metadata_by_user_ids(auth_url, integration_api_key, user_ids, include_orgs):
     user_info_url = auth_url + "/api/backend/v1/user/user_ids"
     params = {"include_orgs": include_orgs}
     body = {"user_ids": user_ids}
-    return _fetch_batch_user_metadata_by_query(user_info_url, api_key, params, body, lambda x: x["user_id"])
+    return _fetch_batch_user_metadata_by_query(user_info_url, integration_api_key, params, body, lambda x: x["user_id"])
 
 
-def _fetch_batch_user_metadata_by_emails(auth_url, api_key, emails, include_orgs):
+def _fetch_batch_user_metadata_by_emails(auth_url, integration_api_key, emails, include_orgs):
     user_info_url = auth_url + "/api/backend/v1/user/emails"
     params = {"include_orgs": include_orgs}
     body = {"emails": emails}
-    return _fetch_batch_user_metadata_by_query(user_info_url, api_key, params, body, lambda x: x["email"])
+    return _fetch_batch_user_metadata_by_query(user_info_url, integration_api_key, params, body, lambda x: x["email"])
 
 
-def _fetch_batch_user_metadata_by_usernames(auth_url, api_key, usernames, include_orgs):
+def _fetch_batch_user_metadata_by_usernames(auth_url, integration_api_key, usernames, include_orgs):
     user_info_url = auth_url + "/api/backend/v1/user/usernames"
     params = {"include_orgs": include_orgs}
     body = {"usernames": usernames}
-    return _fetch_batch_user_metadata_by_query(user_info_url, api_key, params, body, lambda x: x["username"])
+    return _fetch_batch_user_metadata_by_query(user_info_url, integration_api_key, params, body, lambda x: x["username"])
 
 
-def _fetch_batch_user_metadata_by_query(user_info_url, api_key, params, body, key_fn):
-    response = requests.post(user_info_url, params=_format_params(params), json=body, auth=_ApiKeyAuth(api_key))
+def _fetch_batch_user_metadata_by_query(user_info_url, integration_api_key, params, body, key_fn):
+    response = requests.post(user_info_url, params=_format_params(params), json=body, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif not response.ok:
@@ -110,14 +110,14 @@ def _fetch_batch_user_metadata_by_query(user_info_url, api_key, params, body, ke
     return return_value
 
 
-def _fetch_org(auth_url, api_key, org_id):
+def _fetch_org(auth_url, integration_api_key, org_id):
     if not _is_valid_id(org_id):
         return None
 
     url = auth_url + "/api/backend/v1/org/{}".format(org_id)
-    response = requests.get(url, auth=_ApiKeyAuth(api_key))
+    response = requests.get(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return None
     elif response.status_code == 426:
@@ -129,16 +129,16 @@ def _fetch_org(auth_url, api_key, org_id):
     return response.json()
 
 
-def _fetch_org_by_query(auth_url, api_key, page_size, page_number, order_by):
+def _fetch_org_by_query(auth_url, integration_api_key, page_size, page_number, order_by):
     url = auth_url + "/api/backend/v1/org/query"
     params = {
         "page_size": page_size,
         "page_number": page_number,
         "order_by": order_by,
     }
-    response = requests.get(url, params=_format_params(params), auth=_ApiKeyAuth(api_key))
+    response = requests.get(url, params=_format_params(params), auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 426:
@@ -150,7 +150,7 @@ def _fetch_org_by_query(auth_url, api_key, page_size, page_number, order_by):
     return response.json()
 
 
-def _fetch_users_by_query(auth_url, api_key, page_size, page_number, order_by, email_or_username, include_orgs):
+def _fetch_users_by_query(auth_url, integration_api_key, page_size, page_number, order_by, email_or_username, include_orgs):
     url = auth_url + "/api/backend/v1/user/query"
     params = {
         "page_size": page_size,
@@ -159,9 +159,9 @@ def _fetch_users_by_query(auth_url, api_key, page_size, page_number, order_by, e
         "email_or_username": email_or_username,
         "include_orgs": include_orgs,
     }
-    response = requests.get(url, params=_format_params(params), auth=_ApiKeyAuth(api_key))
+    response = requests.get(url, params=_format_params(params), auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 426:
@@ -173,7 +173,7 @@ def _fetch_users_by_query(auth_url, api_key, page_size, page_number, order_by, e
     return response.json()
 
 
-def _fetch_users_in_org(auth_url, api_key, org_id, page_size, page_number, include_orgs):
+def _fetch_users_in_org(auth_url, integration_api_key, org_id, page_size, page_number, include_orgs):
     if not _is_valid_id(org_id):
         return {
             "users": [],
@@ -189,9 +189,9 @@ def _fetch_users_in_org(auth_url, api_key, org_id, page_size, page_number, inclu
         "page_number": page_number,
         "include_orgs": include_orgs,
     }
-    response = requests.get(url, params=_format_params(params), auth=_ApiKeyAuth(api_key))
+    response = requests.get(url, params=_format_params(params), auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 426:
@@ -203,7 +203,7 @@ def _fetch_users_in_org(auth_url, api_key, org_id, page_size, page_number, inclu
     return response.json()
 
 
-def _create_user(auth_url, api_key, email, email_confirmed, send_email_to_confirm_email_address,
+def _create_user(auth_url, integration_api_key, email, email_confirmed, send_email_to_confirm_email_address,
                  ask_user_to_update_password_on_login,
                  password, username, first_name, last_name):
     url = auth_url + "/api/backend/v1/user/"
@@ -218,9 +218,9 @@ def _create_user(auth_url, api_key, email, email_confirmed, send_email_to_confir
         json["first_name"] = first_name
     if last_name is not None:
         json["last_name"] = last_name
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise CreateUserException(response.json())
     elif not response.ok:
@@ -229,7 +229,7 @@ def _create_user(auth_url, api_key, email, email_confirmed, send_email_to_confir
     return response.json()
 
 
-def _update_user_metadata(auth_url, api_key, user_id, username=None, first_name=None, last_name=None, metadata=None):
+def _update_user_metadata(auth_url, integration_api_key, user_id, username=None, first_name=None, last_name=None, metadata=None):
     if not _is_valid_id(user_id):
         return False
 
@@ -244,9 +244,9 @@ def _update_user_metadata(auth_url, api_key, user_id, username=None, first_name=
     if metadata is not None:
         json["metadata"] = metadata
 
-    response = requests.put(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise UpdateUserMetadataException(response.json())
     elif response.status_code == 404:
@@ -257,7 +257,7 @@ def _update_user_metadata(auth_url, api_key, user_id, username=None, first_name=
     return True
 
 
-def _update_user_password(auth_url, api_key, user_id, password, ask_user_to_update_password_on_login):
+def _update_user_password(auth_url, integration_api_key, user_id, password, ask_user_to_update_password_on_login):
     if not _is_valid_id(user_id):
         return False
 
@@ -266,9 +266,9 @@ def _update_user_password(auth_url, api_key, user_id, password, ask_user_to_upda
     if ask_user_to_update_password_on_login is not None:
         json["ask_user_to_update_password_on_login"] = ask_user_to_update_password_on_login
 
-    response = requests.put(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise UpdateUserPasswordException(response.json())
     elif response.status_code == 404:
@@ -279,7 +279,7 @@ def _update_user_password(auth_url, api_key, user_id, password, ask_user_to_upda
     return True
 
 
-def _update_user_email(auth_url, api_key, user_id, new_email, require_email_confirmation):
+def _update_user_email(auth_url, integration_api_key, user_id, new_email, require_email_confirmation):
     if not _is_valid_id(user_id):
         return False
 
@@ -289,9 +289,9 @@ def _update_user_email(auth_url, api_key, user_id, new_email, require_email_conf
         "require_email_confirmation": require_email_confirmation,
     }
 
-    response = requests.put(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise UpdateUserEmailException(response.json())
     elif response.status_code == 404:
@@ -302,7 +302,7 @@ def _update_user_email(auth_url, api_key, user_id, new_email, require_email_conf
     return True
 
 
-def _create_magic_link(auth_url, api_key, email,
+def _create_magic_link(auth_url, integration_api_key, email,
                        redirect_to_url=None, expires_in_hours=None, create_new_user_if_one_doesnt_exist=None):
     url = auth_url + "/api/backend/v1/magic_link"
     json = {"email": email}
@@ -313,9 +313,9 @@ def _create_magic_link(auth_url, api_key, email,
     if create_new_user_if_one_doesnt_exist is not None:
         json["create_new_user_if_one_doesnt_exist"] = create_new_user_if_one_doesnt_exist
 
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:
@@ -324,15 +324,15 @@ def _create_magic_link(auth_url, api_key, email,
     return response.json()
 
 
-def _create_access_token(auth_url, api_key, user_id, duration_in_minutes):
+def _create_access_token(auth_url, integration_api_key, user_id, duration_in_minutes):
     if not _is_valid_id(user_id):
         raise UserNotFoundException()
 
     url = auth_url + "/api/backend/v1/access_token"
     json = {"user_id": user_id, "duration_in_minutes": duration_in_minutes}
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 403:
@@ -343,7 +343,7 @@ def _create_access_token(auth_url, api_key, user_id, duration_in_minutes):
         raise RuntimeError("Unknown error when creating access token")
 
 
-def _migrate_user_from_external_source(auth_url, api_key, email, email_confirmed,
+def _migrate_user_from_external_source(auth_url, integration_api_key, email, email_confirmed,
                                        existing_user_id=None, existing_password_hash=None,
                                        existing_mfa_base32_encoded_secret=None,
                                        ask_user_to_update_password_on_login=False,
@@ -362,9 +362,9 @@ def _migrate_user_from_external_source(auth_url, api_key, email, email_confirmed
         "username": username
     }
 
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:
@@ -373,15 +373,15 @@ def _migrate_user_from_external_source(auth_url, api_key, email, email_confirmed
     return response.json()
 
 
-def _create_org(auth_url, api_key, name, max_users=None):
+def _create_org(auth_url, integration_api_key, name, max_users=None):
     url = auth_url + "/api/backend/v1/org/"
     json = {"name": name}
     if max_users is not None:
         json["max_users"] = max_users
 
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:
@@ -390,7 +390,7 @@ def _create_org(auth_url, api_key, name, max_users=None):
     return response.json()
 
 
-def _update_org_metadata(auth_url, api_key, org_id, name=None, can_setup_saml=None, metadata=None, max_users=None):
+def _update_org_metadata(auth_url, integration_api_key, org_id, name=None, can_setup_saml=None, metadata=None, max_users=None):
     if not _is_valid_id(org_id):
         return False
 
@@ -405,9 +405,9 @@ def _update_org_metadata(auth_url, api_key, org_id, name=None, can_setup_saml=No
     if max_users is not None:
         json["max_users"] = max_users
 
-    response = requests.put(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise UpdateUserMetadataException(response.json())
     elif response.status_code == 404:
@@ -418,13 +418,13 @@ def _update_org_metadata(auth_url, api_key, org_id, name=None, can_setup_saml=No
     return True
 
 
-def _add_user_to_org(auth_url, api_key, user_id, org_id, role):
+def _add_user_to_org(auth_url, integration_api_key, user_id, org_id, role):
     url = auth_url + "/api/backend/v1/org/add_user"
     json = {"user_id": user_id, "org_id": org_id, "role": role}
 
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:
@@ -435,14 +435,14 @@ def _add_user_to_org(auth_url, api_key, user_id, org_id, role):
     return True
 
 
-def _delete_user(auth_url, api_key, user_id):
+def _delete_user(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):
         return False
 
     url = auth_url + "/api/backend/v1/user/{}".format(user_id)
-    response = requests.delete(url, auth=_ApiKeyAuth(api_key))
+    response = requests.delete(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -451,14 +451,14 @@ def _delete_user(auth_url, api_key, user_id):
     return True
 
 
-def _disable_user(auth_url, api_key, user_id):
+def _disable_user(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):
         return False
 
     url = auth_url + "/api/backend/v1/user/{}/disable".format(user_id)
-    response = requests.post(url, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -467,14 +467,14 @@ def _disable_user(auth_url, api_key, user_id):
     return True
 
 
-def _enable_user(auth_url, api_key, user_id):
+def _enable_user(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):
         return False
 
     url = auth_url + "/api/backend/v1/user/{}/enable".format(user_id)
-    response = requests.post(url, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -483,15 +483,15 @@ def _enable_user(auth_url, api_key, user_id):
     return True
 
 
-def _disable_user_2fa(auth_url, api_key, user_id):
+def _disable_user_2fa(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):
         return False
 
     url = auth_url + "/api/backend/v1/user/{}/disable_2fa".format(user_id)
-    response = requests.post(url, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -500,15 +500,15 @@ def _disable_user_2fa(auth_url, api_key, user_id):
     return True
 
 
-def _enable_user_can_create_orgs(auth_url, api_key, user_id):
+def _enable_user_can_create_orgs(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):
         return False
 
     url = auth_url + "/api/backend/v1/user/{}/can_create_orgs/enable".format(user_id)
-    response = requests.put(url, auth=_ApiKeyAuth(api_key))
+    response = requests.put(url, auth=_ApiKeyAuth(integration_api_key))
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -517,15 +517,15 @@ def _enable_user_can_create_orgs(auth_url, api_key, user_id):
     return True
 
 
-def _disable_user_can_create_orgs(auth_url, api_key, user_id):
+def _disable_user_can_create_orgs(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):
         return False
 
     url = auth_url + "/api/backend/v1/user/{}/can_create_orgs/disable".format(user_id)
-    response = requests.put(url, auth=_ApiKeyAuth(api_key))
+    response = requests.put(url, auth=_ApiKeyAuth(integration_api_key))
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -534,14 +534,14 @@ def _disable_user_can_create_orgs(auth_url, api_key, user_id):
     return True
 
 
-def _allow_org_to_setup_saml_connection(auth_url, api_key, org_id):
+def _allow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id):
     if not _is_valid_id(org_id):
         return False
 
     url = auth_url + "/api/backend/v1/org/{}/allow_saml".format(org_id)
-    response = requests.post(url, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -550,14 +550,14 @@ def _allow_org_to_setup_saml_connection(auth_url, api_key, org_id):
     return True
 
 
-def _disallow_org_to_setup_saml_connection(auth_url, api_key, org_id):
+def _disallow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id):
     if not _is_valid_id(org_id):
         return False
 
     url = auth_url + "/api/backend/v1/org/{}/disallow_saml".format(org_id)
-    response = requests.post(url, auth=_ApiKeyAuth(api_key))
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -566,12 +566,12 @@ def _disallow_org_to_setup_saml_connection(auth_url, api_key, org_id):
     return True
 
 
-def _fetch_end_user_api_key(auth_url, api_key, end_user_api_key):
-    url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(end_user_api_key)
-    response = requests.get(url, auth=_ApiKeyAuth(api_key))
+def _fetch_api_key(auth_url, integration_api_key, api_key):
+    url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(api_key)
+    response = requests.get(url, auth=_ApiKeyAuth(integration_api_key))
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif response.status_code == 404:
@@ -582,9 +582,9 @@ def _fetch_end_user_api_key(auth_url, api_key, end_user_api_key):
     return response.json()
 
 
-def _fetch_current_end_user_api_keys(auth_url, api_key, org_id, user_id, user_email, page_size, page_number):
+def _fetch_current_api_keys(auth_url, integration_api_key, org_id, user_id, user_email, page_size, page_number):
     url = auth_url + "/api/backend/v1/end_user_api_keys"
-    
+
     query_params = {}
     if org_id:
         query_params["org_id"] = org_id
@@ -596,11 +596,11 @@ def _fetch_current_end_user_api_keys(auth_url, api_key, org_id, user_id, user_em
         query_params["page_size"] = page_size
     if page_number:
         query_params["page_number"] = page_number
-        
-    response = requests.get(url, auth=_ApiKeyAuth(api_key), params=query_params)
+
+    response = requests.get(url, auth=_ApiKeyAuth(integration_api_key), params=query_params)
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif not response.ok:
@@ -609,9 +609,9 @@ def _fetch_current_end_user_api_keys(auth_url, api_key, org_id, user_id, user_em
     return response.json()
 
 
-def _fetch_archived_end_user_api_keys(auth_url, api_key, org_id, user_id, user_email, page_size, page_number):
+def _fetch_archived_api_keys(auth_url, integration_api_key, org_id, user_id, user_email, page_size, page_number):
     url = auth_url + "/api/backend/v1/end_user_api_keys/archived"
-    
+
     query_params = {}
     if org_id:
         query_params["org_id"] = org_id
@@ -624,10 +624,10 @@ def _fetch_archived_end_user_api_keys(auth_url, api_key, org_id, user_id, user_e
     if page_number:
         query_params["page_number"] = page_number
 
-    response = requests.get(url, auth=_ApiKeyAuth(api_key), params=query_params)
+    response = requests.get(url, auth=_ApiKeyAuth(integration_api_key), params=query_params)
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif not response.ok:
@@ -636,9 +636,9 @@ def _fetch_archived_end_user_api_keys(auth_url, api_key, org_id, user_id, user_e
     return response.json()
 
 
-def _create_end_user_api_key(auth_url, api_key, org_id, user_id, expires_at_seconds, metadata):
+def _create_api_key(auth_url, integration_api_key, org_id, user_id, expires_at_seconds, metadata):
     url = auth_url + "/api/backend/v1/end_user_api_keys"
-    
+
     json = {}
     if org_id:
         json["org_id"] = org_id
@@ -648,11 +648,11 @@ def _create_end_user_api_key(auth_url, api_key, org_id, user_id, expires_at_seco
         json["expires_at_seconds"] = expires_at_seconds
     if metadata:
         json["metadata"] = metadata
-        
-    response = requests.post(url, auth=_ApiKeyAuth(api_key), json=json)
+
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key), json=json)
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif not response.ok:
@@ -661,19 +661,19 @@ def _create_end_user_api_key(auth_url, api_key, org_id, user_id, expires_at_seco
     return response.json()
 
 
-def _update_end_user_api_key(auth_url, api_key, end_user_api_key, expires_at_seconds, metadata):
-    url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(end_user_api_key)
-    
+def _update_api_key(auth_url, integration_api_key, api_key, expires_at_seconds, metadata):
+    url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(api_key)
+
     json = {}
     if expires_at_seconds:
         json["expires_at_seconds"] = expires_at_seconds
     if metadata:
         json["metadata"] = metadata
-    
-    response = requests.put(url, auth=_ApiKeyAuth(api_key), json=json)
+
+    response = requests.put(url, auth=_ApiKeyAuth(integration_api_key), json=json)
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif response.status_code == 404:
@@ -684,12 +684,12 @@ def _update_end_user_api_key(auth_url, api_key, end_user_api_key, expires_at_sec
     return True
 
 
-def _delete_end_user_api_key(auth_url, api_key, end_user_api_key):
-    url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(end_user_api_key)
-    response = requests.delete(url, auth=_ApiKeyAuth(api_key))
+def _delete_api_key(auth_url, integration_api_key, api_key):
+    url = auth_url + "/api/backend/v1/end_user_api_keys/{}".format(api_key)
+    response = requests.delete(url, auth=_ApiKeyAuth(integration_api_key))
 
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif response.status_code == 404:
@@ -700,13 +700,13 @@ def _delete_end_user_api_key(auth_url, api_key, end_user_api_key):
     return True
 
 
-def _validate_end_user_api_key(auth_url, api_key, end_user_api_key):
+def _validate_api_key(auth_url, integration_api_key, api_key):
     url = auth_url + "/api/backend/v1/end_user_api_keys"
-    json = {"api_key_token": end_user_api_key}
-    response = requests.post(url, auth=_ApiKeyAuth(api_key), json=json)
-    
+    json = {"api_key_token": api_key}
+    response = requests.post(url, auth=_ApiKeyAuth(integration_api_key), json=json)
+
     if response.status_code == 401:
-        raise ValueError("api_key is incorrect")
+        raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 400:
         raise EndUserApiKeyException(response.json())
     elif response.status_code == 404:

--- a/propelauth_py/errors.py
+++ b/propelauth_py/errors.py
@@ -27,6 +27,15 @@ class UserNotFoundException(Exception):
     pass
 
 
+class EndUserApiKeyException(Exception):
+    def __init__(self, field_to_errors):
+        self.field_to_errors = field_to_errors
+
+
+class EndUserApiKeyNotFoundException(Exception):
+    pass
+
+
 class UnauthorizedException(Exception):
     def __init__(self, message):
         self.message = message


### PR DESCRIPTION
## Set the maximum users in an org

Set the maximum number of users an org can have with the new **max_users** property on the Org object. Set it with the usual update_org() function, and see the current value with fetch_org(). It's an optional field, and if it's missing orgs will continue to allow unlimited users.

## Let only certain users create orgs

Users can be given permission to create orgs through **enable_user_can_create_orgs**, and that permission can be removed with **disable_user_can_create_orgs**. This special permission overrides the realm-wide users_can_create_orgs. With this new functionality, you can turn off org creation in general, and only grant certain users the privilege. (If the realm-wide users_can_create_orgs is on, then everyone will always be able to create orgs.)

## Disable 2FA on a user

There may be times you will need to disable two-factor authentication for a user. Maybe they lost their device? Here's a simple endpoint to do that: **disable_user_2fa**.

## API Keys

A whole host of functions for managing API Keys. These aren't the Integration API Keys you use to communicate with PropelAuth (in this very library), these are API Keys that can give out to your own clients. We'll happily manage them for you. You can set the optional user, an optional org, optional metadata, and an expiration.

These new API Key endpoints are:

- **fetch_end_user_api_key**
- **fetch_current_end_user_api_keys**
- **fetch_archived_end_user_api_keys**
- **create_end_user_api_key**
- **update_end_user_api_key**
- **delete_end_user_api_key**
- **validate_end_user_api_key**