### PR TITLE
Distinguish Personal from Org API Keys

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -186,10 +186,10 @@ def init_base_auth(auth_url: str, integration_api_key: str, token_verification_m
     def fetch_api_key(api_key_id):
         return _fetch_api_key(auth_url, integration_api_key, api_key_id)
 
-    def fetch_current_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
+    def fetch_current_api_keys(org_id=None, user_id=None, user_email=None, page_size=None, page_number=None):
         return _fetch_current_api_keys(auth_url, integration_api_key, org_id, user_id, user_email, page_size, page_number)
 
-    def fetch_archived_api_keys(org_id: None, user_id: None, user_email: None, page_size: None, page_number: None):
+    def fetch_archived_api_keys(org_id=None, user_id=None, user_email=None, page_size=None, page_number=None):
         return _fetch_archived_api_keys(auth_url, integration_api_key, org_id, user_id, user_email, page_size, page_number)
 
     def create_api_key(org_id=None, user_id=None, expires_at_seconds=None, metadata=None):

--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -10,7 +10,7 @@ from propelauth_py.api import _fetch_token_verification_metadata, TokenVerificat
     _disallow_org_to_setup_saml_connection, _update_user_password, _create_access_token, _disable_user_2fa, \
     _enable_user_can_create_orgs, _disable_user_can_create_orgs, _fetch_api_key, \
     _fetch_current_api_keys, _fetch_archived_api_keys, _create_api_key, \
-    _update_api_key, _delete_api_key, _validate_api_key
+    _update_api_key, _delete_api_key, _validate_api_key, _validate_personal_api_key, _validate_org_api_key
 from propelauth_py.auth_fns import wrap_validate_access_token_and_get_user, \
     wrap_validate_access_token_and_get_user_with_org, \
     wrap_validate_access_token_and_get_user_with_org_by_minimum_role, \
@@ -71,6 +71,8 @@ Auth = namedtuple("Auth", [
     "create_api_key",
     "update_api_key",
     "delete_api_key",
+    "validate_personal_api_key",
+    "validate_org_api_key",
     "validate_api_key",
 ])
 
@@ -199,6 +201,12 @@ def init_base_auth(auth_url: str, integration_api_key: str, token_verification_m
     def delete_api_key(api_key_id):
         return _delete_api_key(auth_url, integration_api_key, api_key_id)
 
+    def validate_personal_api_key(api_key_token):
+        return _validate_personal_api_key(auth_url, integration_api_key, api_key_token)
+
+    def validate_org_api_key(api_key_token):
+        return _validate_org_api_key(auth_url, integration_api_key, api_key_token)
+
     def validate_api_key(api_key_token):
         return _validate_api_key(auth_url, integration_api_key, api_key_token)
 
@@ -275,4 +283,6 @@ def init_base_auth(auth_url: str, integration_api_key: str, token_verification_m
         update_api_key=update_api_key,
         delete_api_key=delete_api_key,
         validate_api_key=validate_api_key,
+        validate_personal_api_key=validate_personal_api_key,
+        validate_org_api_key=validate_org_api_key,
     )

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -683,7 +683,7 @@ def _update_api_key(auth_url, integration_api_key, api_key_id, expires_at_second
     if metadata:
         json["metadata"] = metadata
 
-    response = requests.put(url, auth=_ApiKeyAuth(integration_api_key), json=json)
+    response = requests.patch(url, auth=_ApiKeyAuth(integration_api_key), json=json)
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
@@ -739,7 +739,7 @@ def _validate_org_api_key(auth_url, integration_api_key, api_key_token):
 
 
 def _validate_api_key(auth_url, integration_api_key, api_key_token):
-    url = auth_url + "/api/backend/v1/end_user_api_keys"
+    url = auth_url + "/api/backend/v1/end_user_api_keys/validate"
     json = {"api_key_token": remove_bearer_if_exists(api_key_token)}
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key), json=json)
 

--- a/tests/test_require_user.py
+++ b/tests/test_require_user.py
@@ -34,7 +34,7 @@ def test_validate_with_wrong_token(auth, rsa_keys):
 
 def test_validate_with_expired_token(auth, rsa_keys):
     user_id = random_user_id()
-    access_token = create_access_token({"user_id": user_id}, rsa_keys.private_pem, expires_in=timedelta(minutes=-1))
+    access_token = create_access_token({"user_id": user_id}, rsa_keys.private_pem, expires_in=timedelta(minutes=-5))
     with pytest.raises(UnauthorizedException):
         auth.validate_access_token_and_get_user("Bearer " + access_token)
 


### PR DESCRIPTION
- Clean up the snake => camel case code
- user/org metadata are now real types
- role in org is now the full org_member_info so you can do role/perm checks
- two new validation functions for personal/org keys
