### PR TITLE
added invite_user_to_org endpoint

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -10,7 +10,8 @@ from propelauth_py.api import _fetch_token_verification_metadata, TokenVerificat
     _disallow_org_to_setup_saml_connection, _update_user_password, _create_access_token, _disable_user_2fa, \
     _enable_user_can_create_orgs, _disable_user_can_create_orgs, _fetch_api_key, \
     _fetch_current_api_keys, _fetch_archived_api_keys, _create_api_key, \
-    _update_api_key, _delete_api_key, _validate_api_key, _validate_personal_api_key, _validate_org_api_key
+    _update_api_key, _delete_api_key, _validate_api_key, _validate_personal_api_key, _validate_org_api_key, \
+    _invite_user_to_org
 from propelauth_py.auth_fns import wrap_validate_access_token_and_get_user, \
     wrap_validate_access_token_and_get_user_with_org, \
     wrap_validate_access_token_and_get_user_with_org_by_minimum_role, \
@@ -57,6 +58,7 @@ Auth = namedtuple("Auth", [
     "create_org",
     "update_org_metadata",
     "add_user_to_org",
+    "invite_user_to_org",
     "delete_user",
     "disable_user",
     "enable_user",
@@ -156,6 +158,9 @@ def init_base_auth(auth_url: str, integration_api_key: str, token_verification_m
 
     def add_user_to_org(user_id, org_id, role):
         return _add_user_to_org(auth_url, integration_api_key, user_id, org_id, role)
+
+    def invite_user_to_org(email, org_id, role):
+        return _invite_user_to_org(auth_url, integration_api_key, email, org_id, role)
 
     def delete_user(user_id):
         return _delete_user(auth_url, integration_api_key, user_id)
@@ -267,6 +272,7 @@ def init_base_auth(auth_url: str, integration_api_key: str, token_verification_m
         create_org=create_org,
         update_org_metadata=update_org_metadata,
         add_user_to_org=add_user_to_org,
+        invite_user_to_org=invite_user_to_org,
         enable_user=enable_user,
         disable_user=disable_user,
         delete_user=delete_user,

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -441,6 +441,23 @@ def _add_user_to_org(auth_url, integration_api_key, user_id, org_id, role):
 
     return True
 
+def _invite_user_to_org(auth_url, integration_api_key, email, org_id, role):
+    url = auth_url + "/api/backend/v1/invite_user"
+    json = {"email": email, "org_id": org_id, "role": role}
+
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key), headers=_add_normal_headers())
+
+    if response.status_code == 401:
+        raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 400:
+        raise BadRequestException(response.json())
+    elif response.status_code == 404:
+        return False
+    elif not response.ok:
+        raise RuntimeError("Unknown error when inviting a user to the org")
+
+    return True
+
 
 def _delete_user(auth_url, integration_api_key, user_id):
     if not _is_valid_id(user_id):

--- a/propelauth_py/api.py
+++ b/propelauth_py/api.py
@@ -445,7 +445,7 @@ def _invite_user_to_org(auth_url, integration_api_key, email, org_id, role):
     url = auth_url + "/api/backend/v1/invite_user"
     json = {"email": email, "org_id": org_id, "role": role}
 
-    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key), headers=_add_normal_headers())
+    response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="3.2",
+    version="3.1.3",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="3.1.3",
+    version="3.2",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
You can now invite users to join an organization, and your product, via this nice new endpoint.

This functionality already existed in your frontend, and now it's available in your backend too.

Here's an example of how it works:

```
org_id = "affb4ebb-baa9-4b0e-8d65-4065611d9689"
resp = auth.invite_user_to_org("gilgamesh@uruk.com", org_id, "Admin")
```