### PR TITLE
[HOTFIX] Update names of `update_org` request parameters

### DIFF
--- a/propelauth_py/api/org.py
+++ b/propelauth_py/api/org.py
@@ -209,9 +209,9 @@ def _update_org_metadata(
     if max_users is not None:
         json["max_users"] = max_users
     if can_join_on_email_domain_match is not None:
-        json["domain_autojoin"] = can_join_on_email_domain_match
+        json["autojoin_by_domain"] = can_join_on_email_domain_match
     if members_must_have_email_domain_match is not None:
-        json["domain_restrict"] = members_must_have_email_domain_match
+        json["restrict_to_domain"] = members_must_have_email_domain_match
     if domain is not None:
         json["domain"] = domain
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="3.1.6",
+    version="3.1.7",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The parameters for the `update_org` request were incorrect, and were updated to reflect what they are in the backend (in the `serde(rename)` function)