### PR TITLE
Don't require aud claim yet

### DIFF
--- a/propelauth_py/jwt.py
+++ b/propelauth_py/jwt.py
@@ -10,6 +10,7 @@ OPTIONS = {
     "verify_exp": True,
     "verify_iat": True,
     "verify_iss": True,
+    "verify_aud": False,
     "require": ["exp", "iat", "iss"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="3.1.9",
+    version="3.1.10",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
We've typically not needed an aud claim,
but are starting to roll it out for broader
compatibility. To avoid issues here, we're
going to not require it yet.