### PR TITLE
[TIC-878] Resend email confirmation

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -23,6 +23,7 @@ from propelauth_py.api.user import (
     _disable_user_can_create_orgs,
     _validate_personal_api_key,
     _invite_user_to_org,
+    _resend_email_confirmation,
 )
 from propelauth_py.api.org import (
     _fetch_custom_role_mappings,
@@ -115,6 +116,7 @@ Auth = namedtuple(
         "fetch_users_in_org",
         "create_user",
         "invite_user_to_org",
+        "resend_email_confirmation",
         "update_user_email",
         "update_user_metadata",
         "update_user_password",
@@ -282,6 +284,13 @@ def init_base_auth(
             additional_roles,
         )
 
+    def resend_email_confirmation(user_id):
+        return _resend_email_confirmation(
+            auth_url,
+            integration_api_key,
+            user_id,
+        )
+
     def update_user_email(user_id, new_email, require_email_confirmation):
         return _update_user_email(
             auth_url,
@@ -433,7 +442,9 @@ def init_base_auth(
         return _delete_org(auth_url, integration_api_key, org_id)
 
     def add_user_to_org(user_id, org_id, role, additional_roles=[]):
-        return _add_user_to_org(auth_url, integration_api_key, user_id, org_id, role, additional_roles)
+        return _add_user_to_org(
+            auth_url, integration_api_key, user_id, org_id, role, additional_roles
+        )
 
     def remove_user_from_org(user_id, org_id):
         return _remove_user_from_org(auth_url, integration_api_key, user_id, org_id)
@@ -598,6 +609,7 @@ def init_base_auth(
         fetch_users_in_org=fetch_users_in_org,
         create_user=create_user,
         invite_user_to_org=invite_user_to_org,
+        resend_email_confirmation=resend_email_confirmation,
         update_user_email=update_user_email,
         update_user_metadata=update_user_metadata,
         update_user_password=update_user_password,

--- a/propelauth_py/api/user.py
+++ b/propelauth_py/api/user.py
@@ -356,6 +356,8 @@ def _resend_email_confirmation(auth_url, integration_api_key, user_id):
         raise ValueError("integration_api_key is incorrect")
     elif response.status_code == 404:
         return False
+    elif response.status_code == 429:
+        raise RuntimeError("Too many requests, please try again later.")
     elif not response.ok:
         raise RuntimeError("Unknown error when resending email confirmation")
 

--- a/propelauth_py/api/user.py
+++ b/propelauth_py/api/user.py
@@ -358,6 +358,9 @@ def _resend_email_confirmation(auth_url, integration_api_key, user_id):
         return False
     elif response.status_code == 429:
         raise RuntimeError("Too many requests, please try again later.")
+    elif response.status_code == 400:
+        if response.json().get("user_facing_error"):
+            raise ValueError(response.json().get("user_facing_error"))
     elif not response.ok:
         raise RuntimeError("Unknown error when resending email confirmation")
 

--- a/propelauth_py/api/user.py
+++ b/propelauth_py/api/user.py
@@ -361,6 +361,8 @@ def _resend_email_confirmation(auth_url, integration_api_key, user_id):
     elif response.status_code == 400:
         if response.json().get("user_facing_error"):
             raise ValueError(response.json().get("user_facing_error"))
+        else:
+            raise RuntimeError("Unknown error when resending email confirmation")
     elif not response.ok:
         raise RuntimeError("Unknown error when resending email confirmation")
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="3.1.14",
+    version="3.1.15",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_init_base_auth.py
+++ b/tests/test_init_base_auth.py
@@ -23,6 +23,7 @@ from propelauth_py.api.user import (
     _disable_user_can_create_orgs,
     _validate_personal_api_key,
     _invite_user_to_org,
+    _resend_email_confirmation,
 )
 from propelauth_py.api.org import (
     _fetch_custom_role_mappings,
@@ -100,6 +101,7 @@ IMPORTED_FUNCTIONS = [
     _change_user_role_in_org,
     _delete_org,
     _invite_user_to_org,
+    _resend_email_confirmation,
 ]
 
 


### PR DESCRIPTION
# Background

A new request has been added -- `resend_email_confirmation`. This will allow a user to resend an email confirmation for a created, unconfirmed user. 

## Usage
Here is a basic example usage of this request:
```py
from propelauth_py import init_base_auth

auth = init_base_auth(
    AUTH_URL,
    API_KEY,
)
auth.resend_email_confirmation(<user ID>)
```