### PR TITLE
update legacy_org_id, fetch by legacy user/org ids

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -208,7 +208,11 @@ def init_base_auth(
         return _fetch_org(auth_url, integration_api_key, org_id)
 
     def fetch_org_by_query(
-        page_size=10, page_number=0, order_by=OrgQueryOrderBy.CREATED_AT_ASC, name=None
+        page_size=10,
+        page_number=0,
+        order_by=OrgQueryOrderBy.CREATED_AT_ASC,
+        name=None,
+        legacy_org_id=None,
     ):
         return _fetch_org_by_query(
             auth_url,
@@ -217,6 +221,7 @@ def init_base_auth(
             page_number,
             order_by,
             name,
+            legacy_org_id,
         )
 
     def fetch_custom_role_mappings():
@@ -240,6 +245,7 @@ def init_base_auth(
         order_by=UserQueryOrderBy.CREATED_AT_ASC,
         email_or_username=None,
         include_orgs=False,
+        legacy_user_id=None,
     ):
         return _fetch_users_by_query(
             auth_url,
@@ -249,6 +255,7 @@ def init_base_auth(
             order_by,
             email_or_username,
             include_orgs,
+            legacy_user_id,
         )
 
     def fetch_users_in_org(
@@ -442,6 +449,7 @@ def init_base_auth(
         can_join_on_email_domain_match=None,
         members_must_have_email_domain_match=None,
         domain=None,
+        legacy_org_id=None,
     ):
         return _update_org_metadata(
             auth_url,
@@ -454,6 +462,7 @@ def init_base_auth(
             can_join_on_email_domain_match=can_join_on_email_domain_match,
             members_must_have_email_domain_match=members_must_have_email_domain_match,
             domain=domain,
+            legacy_org_id=legacy_org_id,
         )
 
     def subscribe_org_to_role_mapping(org_id, custom_role_mapping_name):

--- a/propelauth_py/api/org.py
+++ b/propelauth_py/api/org.py
@@ -36,7 +36,7 @@ def _fetch_org(auth_url, integration_api_key, org_id):
 
 
 def _fetch_org_by_query(
-    auth_url, integration_api_key, page_size, page_number, order_by, name
+    auth_url, integration_api_key, page_size, page_number, order_by, name, legacy_org_id
 ):
     url = auth_url + f"{ENDPOINT_PATH}/query"
     params = {
@@ -44,6 +44,7 @@ def _fetch_org_by_query(
         "page_number": page_number,
         "order_by": order_by,
         "name": name,
+        "legacy_org_id": legacy_org_id,
     }
     response = requests.get(
         url, params=_format_params(params), auth=_ApiKeyAuth(integration_api_key)
@@ -264,6 +265,7 @@ def _update_org_metadata(
     can_join_on_email_domain_match=None,  # In the backend, this is the `domain_autojoin` argument.
     members_must_have_email_domain_match=None,  # In the backend, this is the `domain_restrict` argument.
     domain=None,
+    legacy_org_id=None,
     # TODO: Add `require_2fa_by` optional argument.
 ):
     if not _is_valid_id(org_id):
@@ -285,6 +287,8 @@ def _update_org_metadata(
         json["restrict_to_domain"] = members_must_have_email_domain_match
     if domain is not None:
         json["domain"] = domain
+    if legacy_org_id is not None:
+        json["legacy_org_id"] = legacy_org_id
 
     response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:

--- a/propelauth_py/api/user.py
+++ b/propelauth_py/api/user.py
@@ -152,6 +152,7 @@ def _fetch_users_by_query(
     order_by,
     email_or_username,
     include_orgs,
+    legacy_user_id,
 ):
     url = auth_url + f"{ENDPOINT_PATH}/query"
     params = {
@@ -160,6 +161,7 @@ def _fetch_users_by_query(
         "order_by": order_by,
         "email_or_username": email_or_username,
         "include_orgs": include_orgs,
+        "legacy_user_id": legacy_user_id,
     }
     response = requests.get(
         url, params=_format_params(params), auth=_ApiKeyAuth(integration_api_key)


### PR DESCRIPTION
[Context](https://www.notion.so/Add-a-legacy-org-ID-542f0ad4647041a3849459e8d352b89c?pvs=4)
[BE PR](https://github.com/PropelAuth/auth/pull/787)

## After PR
1. update org's legacy_org_id
```python
auth.update_org_metadata(
    org_id="1189c444-8a2d-4c41-8b4b-ae43ce79a492",
    legacy_org_id="<LEGACY_ID>"
)
```
2. fetch/search orgs on the legacy id (case-sensitive string)
```python
auth.fetch_org_by_query(
    legacy_org_id="<LEGACY_ID>"
)
```
3. fetch/search users on the legacy id (case-sensitive string)
```python
auth.fetch_users_by_query(
    legacy_user_id="<LEGACY_ID>"
)
```
