### PR TITLE
support configuration of saml connection configuration for an org

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -34,6 +34,10 @@ from propelauth_py.api.org import (
     _subscribe_org_to_role_mapping,
     _update_org_metadata,
     _validate_org_api_key,
+    _fetch_saml_sp_metadata,
+    _set_saml_idp_metadata,
+    _saml_go_live,
+    _delete_saml_connection,
 )
 from propelauth_py.api.token_verification_metadata import (
     _fetch_token_verification_metadata,
@@ -156,6 +160,10 @@ Auth = namedtuple(
         "validate_personal_api_key",
         "validate_org_api_key",
         "validate_api_key",
+        "fetch_saml_sp_metadata",
+        "set_saml_idp_metadata",
+        "saml_go_live",
+        "delete_saml_connection",
     ],
 )
 
@@ -474,6 +482,35 @@ def init_base_auth(
             org_id,
             custom_role_mapping_name,
         )
+    
+    def fetch_saml_sp_metadata(org_id):
+        return _fetch_saml_sp_metadata(
+            auth_url,
+            integration_api_key,
+            org_id,
+        )
+    
+    def set_saml_idp_metadata(org_id, saml_idp_metadata):
+        return _set_saml_idp_metadata(
+            auth_url,
+            integration_api_key,
+            org_id,
+            saml_idp_metadata,
+        )
+    
+    def saml_go_live(org_id):
+        return _saml_go_live(
+            auth_url,
+            integration_api_key,
+            org_id,
+        )
+    
+    def delete_saml_connection(org_id):
+        return _delete_saml_connection(
+            auth_url,
+            integration_api_key,
+            org_id,
+        )
 
     def delete_org(org_id):
         return _delete_org(auth_url, integration_api_key, org_id)
@@ -683,6 +720,11 @@ def init_base_auth(
         disallow_org_to_setup_saml_connection=disallow_org_to_setup_saml_connection,
         create_org_saml_connection_link=create_org_saml_connection_link,
         revoke_pending_org_invite=revoke_pending_org_invite,
+        # saml setup functions
+        fetch_saml_sp_metadata=fetch_saml_sp_metadata,
+        set_saml_idp_metadata=set_saml_idp_metadata,
+        saml_go_live=saml_go_live,
+        delete_saml_connection=delete_saml_connection,
         # api key functions
         fetch_api_key=fetch_api_key,
         fetch_current_api_keys=fetch_current_api_keys,

--- a/tests/test_init_base_auth.py
+++ b/tests/test_init_base_auth.py
@@ -30,6 +30,10 @@ from propelauth_py.api.org import (
     _subscribe_org_to_role_mapping,
     _update_org_metadata,
     _validate_org_api_key,
+    _fetch_saml_sp_metadata,
+    _set_saml_idp_metadata,
+    _saml_go_live,
+    _delete_saml_connection,
 )
 from propelauth_py.api.user import (
     _clear_user_password,
@@ -110,6 +114,10 @@ IMPORTED_FUNCTIONS = [
     _logout_all_user_sessions,
     _revoke_pending_org_invite,
     _create_org_saml_connection_link,
+    _fetch_saml_sp_metadata,
+    _set_saml_idp_metadata,
+    _saml_go_live,
+    _delete_saml_connection,
 ]
 
 


### PR DESCRIPTION
depends on [BE PR](https://github.com/PropelAuth/auth/pull/844)

## After PR
Here's a naive example of what you can do now
```python
# Setting up an org's saml connection programmatically

get_org_id = lambda: "c19165e3-4c00-4ed2-a321-98d48d4ea890" # for the purpose of the example

org = auth.fetch_org(get_org_id())
print("Org: ", org)

if not org["is_saml_configured"]:
    print("Org does not have SAML configured. Setting up SAML...")

    auth.update_org_metadata(get_org_id(), can_setup_saml=True)

    sp_metadata = auth.fetch_saml_sp_metadata(get_org_id())
    print("SP Metadata: ", sp_metadata)

    # example response...
    '''
    {
        'entity_id': 'https://auth.your.domain/saml/ORGS-URL-SLUG/metadata',
        'acs_url': 'https://auth.your.domain/saml/ORGS-URL-SLUG/acs',
        'logout_url': 'https://auth.your.domain/saml/ORGS-URL-SLUG/logout'
    }
    '''

    # NOT IMPLEMENTED: Upsert this SP metadata to the IdP
    # NOT IMPLEMENTED: Get the metadata needed from the IdP

    example_idp_metadata = {
        "idp_entity_id": "https://sts.windows.net/SOME-UUID/",
        "idp_sso_url": "https://login.microsoftonline.com/SOME-UUID/saml2",
        "idp_certificate": """-----BEGIN CERTIFICATE-----
MyCertificateHere
-----END CERTIFICATE-----
""",
        "provider": "Azure"
    }

    auth.set_saml_idp_metadata(get_org_id(), example_idp_metadata)

    auth.saml_go_live(get_org_id())

else:
    print("Org already has SAML configured. Deleting the connection...")
    auth.delete_saml_connection(get_org_id())
```

## Tests
Built a modified version of the above proof-of-concept within an example app.