### PR TITLE
add domian search to orgs query

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -215,6 +215,7 @@ def init_base_auth(
         order_by=OrgQueryOrderBy.CREATED_AT_ASC,
         name=None,
         legacy_org_id=None,
+        domain=None,
     ):
         return _fetch_org_by_query(
             auth_url,
@@ -224,6 +225,7 @@ def init_base_auth(
             order_by,
             name,
             legacy_org_id,
+            domain,
         )
 
     def fetch_custom_role_mappings():

--- a/propelauth_py/api/org.py
+++ b/propelauth_py/api/org.py
@@ -36,7 +36,7 @@ def _fetch_org(auth_url, integration_api_key, org_id):
 
 
 def _fetch_org_by_query(
-    auth_url, integration_api_key, page_size, page_number, order_by, name, legacy_org_id
+    auth_url, integration_api_key, page_size, page_number, order_by, name, legacy_org_id, domain
 ):
     url = auth_url + f"{ENDPOINT_PATH}/query"
     params = {
@@ -45,6 +45,7 @@ def _fetch_org_by_query(
         "order_by": order_by,
         "name": name,
         "legacy_org_id": legacy_org_id,
+        "domain": domain,
     }
     response = requests.get(
         url, params=_format_params(params), auth=_ApiKeyAuth(integration_api_key)


### PR DESCRIPTION
[BE PR](https://github.com/PropelAuth/auth/pull/845) dependency

## After PR
You can now:
```python
auth.fetch_org_by_query(
    domain="example.com"
)
```
This will only return orgs that have an exact match to the search term w/ either its primary domain or one of its additional domains.
