### PR TITLE
handle EndUserApiKeyRateLimitedException, 4.1.0

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -81,7 +81,12 @@ from propelauth_py.auth_fns import (
     wrap_validate_access_token_and_get_user_with_org_by_minimum_role,
     wrap_validate_access_token_and_get_user_with_org_by_permission,
 )
-from propelauth_py.errors import ForbiddenException, UnauthorizedException
+from propelauth_py.errors import (
+    ForbiddenException,
+    UnauthorizedException,
+    EndUserApiKeyRateLimitedException,
+    EndUserApiKeyException,
+)
 from propelauth_py.types.login_method import (
     EmailConfirmationLinkLoginMethod,
     GeneratedFromBackendApiLoginMethod,

--- a/propelauth_py/api/end_user_api_keys.py
+++ b/propelauth_py/api/end_user_api_keys.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import requests
 from propelauth_py.api import _ApiKeyAuth, _is_valid_hex, remove_bearer_if_exists
-from propelauth_py.errors import EndUserApiKeyException, EndUserApiKeyNotFoundException
+from propelauth_py.errors import EndUserApiKeyException, EndUserApiKeyNotFoundException, EndUserApiKeyRateLimitedException
 from propelauth_py.types.end_user_api_keys import ApiKeyFull, ApiKeyResultPage, ApiKeyNew, ApiKeyValidation
 from propelauth_py.types.user import UserMetadata, OrgFromApiKey
 from propelauth_py.user import OrgMemberInfo
@@ -204,6 +204,8 @@ def _validate_api_key(auth_url, integration_api_key, api_key_token) -> ApiKeyVal
         raise EndUserApiKeyException(response.json())
     elif response.status_code == 404:
         raise EndUserApiKeyNotFoundException()
+    elif response.status_code == 429:
+        raise EndUserApiKeyRateLimitedException(response.json())
     elif not response.ok:
         raise RuntimeError("Unknown error when validating end user api key")
 

--- a/propelauth_py/errors.py
+++ b/propelauth_py/errors.py
@@ -40,6 +40,13 @@ class EndUserApiKeyException(Exception):
 class EndUserApiKeyNotFoundException(Exception):
     pass
 
+class EndUserApiKeyRateLimitedException(Exception):
+    def __init__(self, field_to_errors):
+        self.wait_seconds = field_to_errors.get("wait_seconds")
+        self.user_facing_error = field_to_errors.get("user_facing_error")
+        self.error_code = field_to_errors.get("error_code")
+        self.field_to_errors = field_to_errors
+
 
 class UnauthorizedException(Exception):
     def __init__(self, message):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="4.0.2",
+    version="4.1.0",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# After PR
This introduces graceful handling of rate-limit-specific error thrown when validating an end user's api key. For example, you can now do this
```python
try:
    auth.validate_api_key(end_user_api_key)
    return {"message": "Success"}
except EndUserApiKeyRateLimitedException as e:
    print(e)
    # Example
    # {
    #   'error_code': 'rate_limit_exceeded', 
    #   'user_facing_error': 'Your api keys have hit the rate limit. Wait 58.134504795074 seconds.', 
    #   'wait_seconds': 58.134504795074
    # }
    return {"message": f"Please wait {e.args[0]['wait_seconds']} seconds before trying again."}
except EndUserApiKeyException as e:
    print(e)
    return {"message": "Invalid API key"}
except Exception as e:
    print(e)
    return {"message": "Something went wrong..."}
```

Bumps version to 4.1.0

# Tests
Confirmed expected behavior within an example application.