### PR TITLE
catch RateLimitedException error on all requests

### DIFF
--- a/propelauth_py/__init__.py
+++ b/propelauth_py/__init__.py
@@ -86,6 +86,7 @@ from propelauth_py.errors import (
     UnauthorizedException,
     EndUserApiKeyRateLimitedException,
     EndUserApiKeyException,
+    RateLimitedException,
 )
 from propelauth_py.types.login_method import (
     EmailConfirmationLinkLoginMethod,

--- a/propelauth_py/api/access_token.py
+++ b/propelauth_py/api/access_token.py
@@ -1,6 +1,6 @@
 import requests
 from propelauth_py.api import _ApiKeyAuth, _is_valid_id
-from propelauth_py.errors import BadRequestException, UserNotFoundException
+from propelauth_py.errors import BadRequestException, UserNotFoundException, RateLimitedException
 
 ENDPOINT_PATH = "/api/backend/v1/access_token"
 
@@ -27,6 +27,8 @@ def _create_access_token(auth_url, integration_api_key, user_id, duration_in_min
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 403:

--- a/propelauth_py/api/magic_link.py
+++ b/propelauth_py/api/magic_link.py
@@ -1,7 +1,7 @@
 import requests
 
 from propelauth_py.api import _ApiKeyAuth
-from propelauth_py.errors import BadRequestException
+from propelauth_py.errors import BadRequestException, RateLimitedException
 
 ENDPOINT_PATH = "/api/backend/v1/magic_link"
 
@@ -48,6 +48,8 @@ def _create_magic_link(
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:

--- a/propelauth_py/api/migrate_user.py
+++ b/propelauth_py/api/migrate_user.py
@@ -1,7 +1,7 @@
 import requests
 
 from propelauth_py.api import _ApiKeyAuth
-from propelauth_py.errors import BadRequestException
+from propelauth_py.errors import BadRequestException, RateLimitedException
 from propelauth_py.types.user import CreatedUser
 
 ENDPOINT_PATH = "/api/backend/v1/migrate_user"
@@ -43,6 +43,8 @@ def _migrate_user_from_external_source(
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:

--- a/propelauth_py/api/org.py
+++ b/propelauth_py/api/org.py
@@ -10,6 +10,7 @@ from propelauth_py.errors import (
     BadRequestException,
     EndUserApiKeyException,
     UpdateUserMetadataException,
+    RateLimitedException,
 )
 
 BASE_ENDPOINT_PATH = "/api/backend/v1"
@@ -27,6 +28,8 @@ def _fetch_org(auth_url, integration_api_key, org_id) -> Optional[Organization]:
     response = requests.get(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return None
     elif response.status_code == 426:
@@ -72,6 +75,8 @@ def _fetch_org_by_query(
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 426:
@@ -111,6 +116,8 @@ def _fetch_custom_role_mappings(auth_url, integration_api_key) -> CustomRoleMapp
     response = requests.get(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 426:
         raise RuntimeError(
             "Cannot use organizations unless B2B support is enabled. Enable it in your PropelAuth "
@@ -157,6 +164,8 @@ def _fetch_pending_invites(
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 426:
         raise RuntimeError(
             "Cannot use organizations unless B2B support is enabled. Enable it in your PropelAuth "
@@ -198,6 +207,8 @@ def _fetch_saml_sp_metadata(auth_url, integration_api_key, org_id) -> Optional[S
     response = requests.get(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return None
     elif not response.ok:
@@ -243,6 +254,8 @@ def _create_org(
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:
@@ -263,6 +276,8 @@ def _allow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id) -
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -279,6 +294,8 @@ def _disallow_org_to_setup_saml_connection(auth_url, integration_api_key, org_id
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -302,6 +319,8 @@ def _create_org_saml_connection_link(
     response = requests.post(url, json=body, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 426:
@@ -329,6 +348,8 @@ def _add_user_to_org(
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:
@@ -346,6 +367,8 @@ def _remove_user_from_org(auth_url, integration_api_key, user_id, org_id) -> boo
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:
@@ -370,6 +393,8 @@ def _change_user_role_in_org(
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:
@@ -396,6 +421,8 @@ def _set_saml_idp_metadata(auth_url, integration_api_key, org_id, saml_idp_metad
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:
@@ -414,6 +441,8 @@ def _saml_go_live(auth_url, integration_api_key, org_id) -> bool:
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:
@@ -465,6 +494,8 @@ def _update_org_metadata(
     response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise UpdateUserMetadataException(response.json())
     elif response.status_code == 404:
@@ -492,6 +523,8 @@ def _subscribe_org_to_role_mapping(
     response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise UpdateUserMetadataException(response.json())
     elif response.status_code == 404:
@@ -518,6 +551,8 @@ def _delete_org(auth_url, integration_api_key, org_id) -> bool:
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -533,6 +568,8 @@ def _revoke_pending_org_invite(auth_url, integration_api_key, org_id, invitee_em
     response = requests.delete(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif not response.ok:
@@ -550,6 +587,8 @@ def _delete_saml_connection(auth_url, integration_api_key, org_id) -> bool:
     response = requests.delete(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise BadRequestException(response.json())
     elif response.status_code == 404:

--- a/propelauth_py/api/token_verification_metadata.py
+++ b/propelauth_py/api/token_verification_metadata.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import requests
 from propelauth_py.api import _ApiKeyAuth, TokenVerificationMetadata
+from propelauth_py.errors import RateLimitedException
 
 ENDPOINT_PATH = "/api/v1/token_verification_metadata"
 
@@ -22,6 +23,8 @@ def _fetch_token_verification_metadata(
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise ValueError("Bad request")
     elif response.status_code == 404:

--- a/propelauth_py/api/user.py
+++ b/propelauth_py/api/user.py
@@ -11,6 +11,7 @@ from propelauth_py.errors import (
     UpdateUserEmailException,
     UpdateUserMetadataException,
     UpdateUserPasswordException,
+    RateLimitedException,
 )
 
 ENDPOINT_PATH = "/api/backend/v1/user"
@@ -47,6 +48,8 @@ def _fetch_user_signup_query_params_by_user_id(
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return None
     elif not response.ok:
@@ -82,6 +85,8 @@ def _fetch_user_metadata_by_query(integration_api_key, user_info_url, query) -> 
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 404:
@@ -158,6 +163,8 @@ def _fetch_batch_user_metadata_by_query(
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif not response.ok:
@@ -195,6 +202,8 @@ def _fetch_users_by_query(
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 426:
@@ -265,6 +274,8 @@ def _fetch_users_in_org(
     )
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise ValueError("Bad request: " + response.text)
     elif response.status_code == 426:
@@ -350,6 +361,8 @@ def _create_user(
     response = requests.post(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise CreateUserException(response.json())
     elif not response.ok:
@@ -369,6 +382,8 @@ def _disable_user(auth_url, integration_api_key, user_id) -> bool:
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -385,6 +400,8 @@ def _enable_user(auth_url, integration_api_key, user_id) -> bool:
     response = requests.post(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -402,6 +419,8 @@ def _disable_user_2fa(auth_url, integration_api_key, user_id) -> bool:
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -428,6 +447,8 @@ def _invite_user_to_org(
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         try:
             response_json = response.json()
@@ -455,6 +476,8 @@ def _resend_email_confirmation(auth_url, integration_api_key, user_id) -> bool:
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif response.status_code == 429:
@@ -479,6 +502,8 @@ def _logout_all_user_sessions(auth_url, integration_api_key, user_id) -> bool:
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -525,6 +550,8 @@ def _update_user_metadata(
     response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise UpdateUserMetadataException(response.json())
     elif response.status_code == 404:
@@ -555,6 +582,8 @@ def _update_user_password(
     response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise UpdateUserPasswordException(response.json())
     elif response.status_code == 404:
@@ -573,6 +602,8 @@ def _clear_user_password(auth_url, integration_api_key, user_id) -> bool:
     response = requests.put(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise UpdateUserEmailException(response.json())
     elif response.status_code == 404:
@@ -598,6 +629,8 @@ def _update_user_email(
     response = requests.put(url, json=json, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 400:
         raise UpdateUserEmailException(response.json())
     elif response.status_code == 404:
@@ -617,6 +650,8 @@ def _enable_user_can_create_orgs(auth_url, integration_api_key, user_id) -> bool
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -634,6 +669,8 @@ def _disable_user_can_create_orgs(auth_url, integration_api_key, user_id) -> boo
 
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:
@@ -653,6 +690,8 @@ def _delete_user(auth_url, integration_api_key, user_id) -> bool:
     response = requests.delete(url, auth=_ApiKeyAuth(integration_api_key))
     if response.status_code == 401:
         raise ValueError("integration_api_key is incorrect")
+    elif response.status_code == 429:
+        raise RateLimitedException(response.text)
     elif response.status_code == 404:
         return False
     elif not response.ok:

--- a/propelauth_py/errors.py
+++ b/propelauth_py/errors.py
@@ -47,6 +47,10 @@ class EndUserApiKeyRateLimitedException(Exception):
         self.error_code = field_to_errors.get("error_code")
         self.field_to_errors = field_to_errors
 
+class RateLimitedException(Exception):
+    def __init__(self, error_message):
+        self.error_message = error_message
+
 
 class UnauthorizedException(Exception):
     def __init__(self, message):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 setup(
     name="propelauth-py",
-    version="4.1.1",
+    version="4.2.0",
     description="A python authentication library",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## After PR
**Bumps minor version to 4.2.0**

Currently, if a customer's BE hits a PropelAuth rate limit, this library converts the response into 
```
RuntimeError("Unknown error when...")
```
After this change, these responses will instead be converted to 
```
RateLimitedException("Rate limited. Please wait X seconds before trying again.")
```
All `validate*_api_key` methods perform additional parsing on the error body in the case of a 429 to distinguish between rate limits set by customers to be enforced on end-users (ie `EndUserApiKeyRateLimitedException`) and rate limits set and imposed by PropelAuth (ie the new `RateLimitException`).

## Test
1. Setup a local dev environment with a rate limit on the hostname of `5 request / 10 seconds` and a rate limit of `10 requests / 1 minute` on personal api keys. 
2. Spammed an example app with w/ a personal api key
3. validated the example app's BE logged the details of the PropelAuth rate limit when that was hit and returned a detailed rate limit error to the client when the personal-api-key rate limit was hit.