### PR TITLE
build and publish wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,9 @@ jobs:
       run: python -m pytest
 
     - name: Build a binary wheel and a source tarball
-      run: python setup.py sdist
+      run: |
+        python -m pip install build
+        python -m build
 
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Direct invocation of setup.py is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).  Build and publish a wheel.