### PR TITLE
Add AsyncAuth with validate_api_key method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+httpx
 pyjwt[crypto]>=2,<3
 requests
 pytest


### PR DESCRIPTION
Introduce `AsyncAuth` class for asyncio support, starting with the `AsyncAuth.validate_api_key` method. 

Tested manually in dev environment.

This brings in [httpx](https://github.com/encode/httpx) as a dependency, which could replace `requests` in the future.